### PR TITLE
feat: transverter range limits extended

### DIFF
--- a/src/dialog_settings.c
+++ b/src/dialog_settings.c
@@ -1020,7 +1020,7 @@ static uint8_t make_transverter(uint8_t row, uint8_t n) {
     dialog_item(&dialog, obj);
 
     lv_spinbox_set_value(obj, transverter->from / 1000000L);
-    lv_spinbox_set_range(obj, 100, 500);
+    lv_spinbox_set_range(obj, 70, 500);
     lv_spinbox_set_digit_format(obj, 3, 0);
     lv_spinbox_set_digit_step_direction(obj, LV_DIR_LEFT);
     lv_obj_set_size(obj, SMALL_2, 56);
@@ -1035,7 +1035,7 @@ static uint8_t make_transverter(uint8_t row, uint8_t n) {
     dialog_item(&dialog, obj);
 
     lv_spinbox_set_value(obj, transverter->to / 1000000L);
-    lv_spinbox_set_range(obj, 100, 500);
+    lv_spinbox_set_range(obj, 70, 500);
     lv_spinbox_set_digit_format(obj, 3, 0);
     lv_spinbox_set_digit_step_direction(obj, LV_DIR_LEFT);
     lv_obj_set_size(obj, SMALL_2, 56);


### PR DESCRIPTION
This update extends the lower limit of allowed transverter frequencies in the custom firmware for the Xiegu X6100 to accommodate amateur radio operators in countries where the 4m band (70 MHz) is available. Previously, the lower frequency limit for transverter operation was restricted to 100 MHz, which excluded the 4m band from use with external transverter.

**Details**

- New Lower Limit: The transverter frequency range now supports frequencies below 100 MHz, down to 70 MHz.
- This change allows operators in regions where the 4m amateur band is allocated (typically around 70 MHz) to utilize their X6100 transceiver more effectively with external transverters.