### PR TITLE
reload the atu cache from db on save

### DIFF
--- a/src/cfg/atu.c
+++ b/src/cfg/atu.c
@@ -122,7 +122,7 @@ int cfg_atu_save_network(uint32_t network) {
         LV_LOG_ERROR("Failed save atu_params: %s", sqlite3_errmsg(db));
     } else {
         rc = 0;
-        add_atu_net_to_cache(freq, network);
+        load_all_atu_for_ant(ant_id);
         subject_set_int(atu_network.loaded, true);
         subject_set_int(atu_network.network, network);
     }


### PR DESCRIPTION
as it was, it was updating the DB to update the nearest atu row with a new freq, but in cache, it only added and left the old freq in place, so you'd get the cache littered with lots of near networks that would thrash ATU as you spin past them on the VFO.