### PR TITLE
Fix handling of long and prefixed callsigns in FT8 encoding

### DIFF
--- a/src/dialog_callsign.c
+++ b/src/dialog_callsign.c
@@ -11,6 +11,8 @@
 #include "main_screen.h"
 #include "dialog.h"
 #include "events.h"
+#include "msg.h"
+#include <string.h>
 
 static void construct_cb(lv_obj_t *parent);
 static void destruct_cb();
@@ -27,7 +29,11 @@ static dialog_t             dialog = {
 dialog_t                    *dialog_callsign = &dialog;
 
 static bool edit_ok() {
-    params_str_set(&params.callsign, textarea_window_get());
+    const char *callsign = textarea_window_get();
+    params_str_set(&params.callsign, callsign);
+    if (strlen(callsign) > 6) {
+        msg_schedule_text_fmt("Callsign >6chars may cause FT8 issues");
+    }
     dialog_destruct(&dialog);
     return true;
 }

--- a/src/dialog_callsign.c
+++ b/src/dialog_callsign.c
@@ -32,7 +32,7 @@ static bool edit_ok() {
     const char *callsign = textarea_window_get();
     params_str_set(&params.callsign, callsign);
     if (strlen(callsign) > 6) {
-        msg_schedule_text_fmt("Callsign >6chars may cause FT8 issues");
+        msg_schedule_text_fmt("FT8 may fail with long calls");
     }
     dialog_destruct(&dialog);
     return true;

--- a/src/dialog_callsign.c
+++ b/src/dialog_callsign.c
@@ -31,9 +31,9 @@ dialog_t                    *dialog_callsign = &dialog;
 static bool edit_ok() {
     const char *callsign = textarea_window_get();
     params_str_set(&params.callsign, callsign);
-    // if (strlen(callsign) > 6) {
-        // usleep(1000000);
-    // }
+    if (strlen(callsign) > 6) {
+        msg_schedule_text_fmt("Callsign >6chars may cause FT8 issues");
+    }
     dialog_destruct(&dialog);
     return true;
 }
@@ -56,7 +56,7 @@ static void construct_cb(lv_obj_t *parent) {
     lv_textarea_set_max_length(text, sizeof(params.callsign.x) - 1);
     lv_textarea_set_placeholder_text(text, "Callsign");
     lv_obj_add_event_cb(text, key_cb, LV_EVENT_KEY, NULL);
-    msg_schedule_text_fmt("Test");
+
     textarea_window_set(params.callsign.x);
 }
 

--- a/src/dialog_callsign.c
+++ b/src/dialog_callsign.c
@@ -31,9 +31,10 @@ dialog_t                    *dialog_callsign = &dialog;
 static bool edit_ok() {
     const char *callsign = textarea_window_get();
     params_str_set(&params.callsign, callsign);
-    if (strlen(callsign) > 6) {
+    // if (strlen(callsign) > 6) {
         msg_schedule_text_fmt("Callsign >6chars may cause FT8 issues");
-    }
+        usleep(1000000);
+    // }
     dialog_destruct(&dialog);
     return true;
 }

--- a/src/dialog_callsign.c
+++ b/src/dialog_callsign.c
@@ -32,8 +32,7 @@ static bool edit_ok() {
     const char *callsign = textarea_window_get();
     params_str_set(&params.callsign, callsign);
     // if (strlen(callsign) > 6) {
-        msg_schedule_text_fmt("Callsign >6chars may cause FT8 issues");
-        usleep(1000000);
+        // usleep(1000000);
     // }
     dialog_destruct(&dialog);
     return true;
@@ -57,7 +56,7 @@ static void construct_cb(lv_obj_t *parent) {
     lv_textarea_set_max_length(text, sizeof(params.callsign.x) - 1);
     lv_textarea_set_placeholder_text(text, "Callsign");
     lv_obj_add_event_cb(text, key_cb, LV_EVENT_KEY, NULL);
-
+    msg_schedule_text_fmt("Test");
     textarea_window_set(params.callsign.x);
 }
 

--- a/src/dialog_ft8.c
+++ b/src/dialog_ft8.c
@@ -911,7 +911,7 @@ static void cell_press_cb(lv_event_t * e) {
             (cell_data->cell_type == CELL_TX_MSG) ||
             (cell_data->cell_type == CELL_RX_INFO)
         ) {
-            msg_schedule_text_fmt("What should I do about it?");
+            msg_schedule_text_fmt("What should I do about it? what what ");
         } else {
             ftx_qso_processor_start_qso(qso_processor, &cell_data->meta, &tx_msg);
             if (strlen(tx_msg.msg) > 0) {

--- a/src/dialog_ft8.c
+++ b/src/dialog_ft8.c
@@ -1005,10 +1005,19 @@ static bool get_time_slot(struct timespec now, float *sec_since_start) {
  * Create CQ TX message
  */
 static void make_cq_msg(const char *callsign, const char *qth, const char *cq_mod, char *text) {
-    if (strlen(cq_mod)) {
-        snprintf(text, FTX_MAX_MESSAGE_LENGTH, "CQ_%s %s %s", cq_mod, callsign, qth);
+    if (is_prefixed_callsign(callsign)) {
+        // If prefixed, omit QTH
+        if (strlen(cq_mod)) {
+            snprintf(text, FTX_MAX_MESSAGE_LENGTH, "CQ_%s %s", cq_mod, callsign);
+        } else {
+            snprintf(text, FTX_MAX_MESSAGE_LENGTH, "CQ %s", callsign);
+        }
     } else {
-        snprintf(text, FTX_MAX_MESSAGE_LENGTH, "CQ %s %s", callsign, qth);
+        if (strlen(cq_mod)) {
+            snprintf(text, FTX_MAX_MESSAGE_LENGTH, "CQ_%s %s %s", cq_mod, callsign, qth);
+        } else {
+            snprintf(text, FTX_MAX_MESSAGE_LENGTH, "CQ %s %s", callsign, qth);
+        }
     }
 }
 

--- a/src/dialog_ft8.c
+++ b/src/dialog_ft8.c
@@ -911,7 +911,7 @@ static void cell_press_cb(lv_event_t * e) {
             (cell_data->cell_type == CELL_TX_MSG) ||
             (cell_data->cell_type == CELL_RX_INFO)
         ) {
-            msg_schedule_text_fmt("What should I do about it? what what ");
+            msg_schedule_text_fmt("What should I do about it?");
         } else {
             ftx_qso_processor_start_qso(qso_processor, &cell_data->meta, &tx_msg);
             if (strlen(tx_msg.msg) > 0) {

--- a/src/ft8/qso.cpp
+++ b/src/ft8/qso.cpp
@@ -356,7 +356,11 @@ static std::string make_answer_text(ftx_msg_type_t last_rx_type, std::string rem
     int  len = 0;
     switch (last_rx_type) {
     case FTX_MSG_TYPE_CQ:
-        len = snprintf(answer, 35, "%s %s %s", remote_callsign.c_str(), local_callsign.c_str(), grid.c_str());
+        if (is_prefixed_callsign(local_callsign.c_str()) || is_prefixed_callsign(remote_callsign.c_str())){
+            len = snprintf(answer, 35, "%s %s", remote_callsign.c_str(), local_callsign.c_str());
+        } else {
+            len = snprintf(answer, 35, "%s %s %s", local_callsign.c_str(), remote_callsign.c_str(), grid.c_str());
+        }
         break;
     case FTX_MSG_TYPE_GRID:
         len = snprintf(answer, 35, "%s %s %+03d", remote_callsign.c_str(), local_callsign.c_str(), local_snr);

--- a/src/ft8/utils.c
+++ b/src/ft8/utils.c
@@ -1,43 +1,67 @@
 #include "utils.h"
 
+#include <ctype.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
-#include <ctype.h>
+
+bool is_prefixed_callsign(const char *callsign) {
+  const char *slash = strchr(callsign, '/');
+  if (!slash || slash == callsign) {
+    return false;
+  }
+
+  size_t prefix_len = slash - callsign;
+  if (prefix_len < 1 || prefix_len > 3) {
+    return false;
+  }
+
+  // Check pattern: 1–2 letters, optionally followed by 1 digit
+  if (prefix_len == 1) {
+    return isalpha(callsign[0]);
+  } else if (prefix_len == 2) {
+    return isalpha(callsign[0]) && isalpha(callsign[1]);
+  } else if (prefix_len == 3) {
+    return isalpha(callsign[0]) && isalpha(callsign[1]) && isdigit(callsign[2]);
+  }
+
+  return false;
+}
 
 /**
  * Check that text is CQ modifier (3 digits or 1 to 4 letters)
  */
 bool is_cq_modifier(const char *text) {
-    size_t len = strlen(text);
-    char   c;
+  size_t len = strlen(text);
+  char c;
 
+  // Check for 3 digits
+  bool correct = true;
+  if (len == 3) {
     // Check for 3 digits
-    bool correct = true;
-    if (len == 3) {
-        // Check for 3 digits
-        for (size_t i = 0; i < len; i++) {
-            if ((text[i] < '0') || (text[i] > '9')) {
-                correct = false;
-                break;
-            }
-        }
-        if (correct) {
-            return true;
-        }
+    for (size_t i = 0; i < len; i++) {
+      if ((text[i] < '0') || (text[i] > '9')) {
+        correct = false;
+        break;
+      }
     }
-    // Check for 1 to 4 letters
-    correct = true;
-    if ((len >= 1) && (len <= 4)) {
-        for (size_t i = 0; i < len; i++) {
-            c = toupper(text[i]);
-            if ((c < 'A') || (c > 'Z')) {
-                correct = false;
-                break;
-            }
-        }
-        if (correct) {
-            return true;
-        }
+    if (correct) {
+      return true;
     }
-    return false;
+  }
+  // Check for 1 to 4 letters
+  correct = true;
+  if ((len >= 1) && (len <= 4)) {
+    for (size_t i = 0; i < len; i++) {
+      c = toupper(text[i]);
+      if ((c < 'A') || (c > 'Z')) {
+        correct = false;
+        break;
+      }
+    }
+    if (correct) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/src/ft8/utils.h
+++ b/src/ft8/utils.h
@@ -2,4 +2,5 @@
 
 #include <stdbool.h>
 
+bool is_prefixed_callsign(const char *callsign);
 bool is_cq_modifier(const char *text);


### PR DESCRIPTION
This PR addresses issues with encoding callsigns longer than 6 characters, especially those with country prefixes (e.g., SV9/SP9HGN/P). The application now skips adding the grid locator in such cases to stay within FT8 frame constraints. A warning is also shown when setting a callsign longer than 6 characters, as this may lead to hash-based encoding and potential decoding issues. These changes improve compatibility with FT8 encoding rules and help prevent incomplete transmissions.