### PR TITLE
Knobs function preview on main screen

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(${PROJECT_NAME} PUBLIC
     textarea_window.c cw_encoder.c buttons.cpp vol.c recorder.c
     voice.cpp cw_tune_ui.c adif.c qso_log.c scheduler.cpp
     dialog_wifi.c wifi.cpp controls.cpp usb_devices.cpp
+    knobs.c
 )
 
 add_subdirectory(fonts)

--- a/src/buttons.cpp
+++ b/src/buttons.cpp
@@ -32,7 +32,6 @@ typedef struct {
     button_item_t   *item;
 } button_t;
 
-static uint8_t        btn_height = 62;
 static button_t       btn[BUTTONS];
 static lv_obj_t      *parent_obj = NULL;
 static buttons_page_t *cur_page   = NULL;
@@ -539,7 +538,7 @@ void buttons_init(lv_obj_t *parent) {
         }
     }
 
-    uint16_t y = 480 - btn_height;
+    uint16_t y = 480 - BTN_HEIGHT;
     uint16_t x = 0;
     uint16_t width = 800 / 5;
 
@@ -552,7 +551,7 @@ void buttons_init(lv_obj_t *parent) {
         lv_obj_add_style(f, &btn_disabled_style, LV_STATE_DISABLED);
 
         lv_obj_set_pos(f, x, y);
-        lv_obj_set_size(f, width, btn_height);
+        lv_obj_set_size(f, width, BTN_HEIGHT);
         x += width;
 
         lv_obj_t *label = lv_label_create(f);
@@ -707,12 +706,12 @@ static void button_action_cb(button_item_t *item) {
 
 static void button_vol_update_cb(button_item_t *item) {
     vol_set_mode((vol_mode_t)item->data);
-    vol_update(0, true);
+    vol_update(0, true, true);
 }
 
 static void button_mfk_update_cb(button_item_t *item) {
     mfk_set_mode((mfk_mode_t)item->data);
-    mfk_update(0, true);
+    mfk_update(0, true, true);
 }
 
 static void button_vol_hold_cb(button_item_t *item) {

--- a/src/buttons.h
+++ b/src/buttons.h
@@ -25,6 +25,8 @@ extern "C" {
 #include "mfk.h"
 #include "vol.h"
 
+#define BTN_HEIGHT 62
+
 typedef enum {
     BTN_EMPTY,
     BTN_TEXT,

--- a/src/knobs.c
+++ b/src/knobs.c
@@ -1,0 +1,86 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI
+ *
+ *  Copyright (c) 2022-2023 Belousov Oleg aka R1CBU
+ *  Copyright (c) 2025 Adrian Grzeca SQ5FOX
+ */
+
+
+#include "knobs.h"
+
+#include "styles.h"
+#include "buttons.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static lv_obj_t *obj_label_vol_knob = NULL;
+static lv_obj_t *obj_label_mfk_knob = NULL;
+
+lv_obj_t * knobs_init(lv_obj_t * parent) {
+    // Basic pos. calc.
+    uint16_t y = 480 - BTN_HEIGHT;
+    uint16_t x = 0;
+
+    // Set global style
+    lv_style_set_width(&knobs_style, 400);
+    lv_style_set_height(&knobs_style, KNOBS_HEIGHT);
+
+    // Volume knob label
+    obj_label_vol_knob = lv_label_create(parent);
+    lv_obj_add_style(obj_label_vol_knob, &knobs_style, 0);
+    lv_obj_set_style_text_align(obj_label_vol_knob, LV_TEXT_ALIGN_LEFT, 0);
+    lv_obj_set_style_text_font(obj_label_vol_knob, &sony_30, 0);
+    lv_obj_set_pos(obj_label_vol_knob, x, y - KNOBS_HEIGHT * 2);
+
+    // MFK knob label
+    obj_label_mfk_knob = lv_label_create(parent);
+    lv_obj_add_style(obj_label_mfk_knob, &knobs_style, 0);
+    lv_obj_set_style_text_align(obj_label_mfk_knob, LV_TEXT_ALIGN_LEFT, 0);
+    lv_obj_set_style_text_font(obj_label_mfk_knob, &sony_30, 0);
+    lv_obj_set_pos(obj_label_mfk_knob, x, y - KNOBS_HEIGHT * 1);
+}
+
+// Yes i know it can be deduplicated but i don't care
+
+void knobs_update_vol(const char * fmt, ...) {
+    va_list args;
+    static char buf[256];
+    static char buf2[256];
+
+    // Skip if object is still NULL
+    if(obj_label_vol_knob == NULL) return;
+
+    // Format message
+    va_start(args, fmt);
+    vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+
+    // Generate final string
+    snprintf(buf2, sizeof(buf2), "VOL -> %s", buf);
+    
+    // Update label
+    lv_label_set_text(obj_label_vol_knob, buf2);
+}
+
+void knobs_update_mfk(const char * fmt, ...) {
+    va_list args;
+    static char buf[256];
+    static char buf2[256];
+
+    // Skip if object is still NULL
+    if(obj_label_mfk_knob == NULL) return;
+
+    // Format message
+    va_start(args, fmt);
+    vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+
+    // Generate final string
+    snprintf(buf2, sizeof(buf2), "MFK -> %s", buf);
+    
+    // Update label
+    lv_label_set_text(obj_label_mfk_knob, buf2);
+}

--- a/src/knobs.h
+++ b/src/knobs.h
@@ -1,0 +1,20 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI
+ *
+ *  Copyright (c) 2022-2023 Belousov Oleg aka R1CBU
+ *  Copyright (c) 2025 Adrian Grzeca SQ5FOX
+ */
+
+#pragma once
+
+#include "lvgl/lvgl.h"
+
+#include <unistd.h>
+
+#define KNOBS_HEIGHT 30
+
+lv_obj_t * knobs_init(lv_obj_t * parent);
+void knobs_update_vol(const char * fmt, ...);
+void knobs_update_mfk(const char * fmt, ...);

--- a/src/main_screen.c
+++ b/src/main_screen.c
@@ -18,6 +18,7 @@
 #include "msg_tiny.h"
 #include "dsp.h"
 #include "clock.h"
+#include "knobs.h"
 #include "cw_tune_ui.h"
 #include "info.h"
 #include "meter.h"
@@ -70,6 +71,7 @@ static lv_obj_t     *msg;
 static lv_obj_t     *msg_tiny;
 static lv_obj_t     *meter;
 static lv_obj_t     *tx_info;
+static lv_obj_t     *knobs;
 
 static void freq_shift(int16_t diff);
 static void next_freq_step(bool up);
@@ -849,12 +851,12 @@ static void spectrum_key_cb(lv_event_t * e) {
 
         case KEY_VOL_LEFT_EDIT:
         case '[':
-            vol_update(-1, false);
+            vol_update(-1, false, true);
             break;
 
         case KEY_VOL_RIGHT_EDIT:
         case ']':
-            vol_update(+1, false);
+            vol_update(+1, false, true);
             break;
 
         case KEY_VOL_LEFT_SELECT:
@@ -874,7 +876,7 @@ static void spectrum_key_cb(lv_event_t * e) {
         case LV_KEY_LEFT:
             switch (mfk_state) {
                 case MFK_STATE_EDIT:
-                    mfk_update(-1, false);
+                    mfk_update(-1, false, true);
                     break;
 
                 case MFK_STATE_SELECT:
@@ -886,7 +888,7 @@ static void spectrum_key_cb(lv_event_t * e) {
         case LV_KEY_RIGHT:
             switch (mfk_state) {
                 case MFK_STATE_EDIT:
-                    mfk_update(+1, false);
+                    mfk_update(+1, false, true);
                     break;
 
                 case MFK_STATE_SELECT:
@@ -908,7 +910,7 @@ static void spectrum_key_cb(lv_event_t * e) {
                         voice_say_text_fmt("Edit mode");
                         break;
                 }
-                vol_update(0, false);
+                vol_update(0, false, true);
             }
             break;
 
@@ -959,7 +961,7 @@ static void spectrum_pressed_cb(lv_event_t * e) {
             voice_say_text_fmt("Edit mode");
             break;
     }
-    mfk_update(0, false);
+    mfk_update(0, false, true);
 }
 
 static void keys_enable_cb(lv_timer_t *t) {
@@ -1066,6 +1068,7 @@ lv_obj_t * main_screen() {
     msg_tiny = msg_tiny_init(obj);
 
     clock_init(obj);
+    knobs_init(obj);
     info_init(obj);
 
     meter = meter_init(obj);
@@ -1073,7 +1076,7 @@ lv_obj_t * main_screen() {
 
     cw_tune_init(obj);
 
-    msg_schedule_text_fmt("X6100 de R1CBU " VERSION);
+    msg_schedule_text_fmt("X6100 de R1CBU ES SQ5FOX " VERSION);
 
     subject_add_delayed_observer(freq_lock, on_fg_freq_change, NULL);
     subject_add_delayed_observer(cfg_cur.band->split.val, on_fg_freq_change, NULL);
@@ -1087,6 +1090,10 @@ lv_obj_t * main_screen() {
 
     subject_add_delayed_observer(cfg_cur.bg_freq, on_fg_freq_change, NULL);
     on_fg_freq_change(cfg_cur.bg_freq, NULL);
+
+    // Update knobs
+    vol_update(0, false, false);
+    mfk_update(0, false, false);
 
     return obj;
 }

--- a/src/mfk.cpp
+++ b/src/mfk.cpp
@@ -29,6 +29,7 @@ extern "C" {
     #include "band_info.h"
     #include "pubsub_ids.h"
     #include "meter.h"
+    #include "knobs.h"
 
     #include "lvgl/lvgl.h"
 }
@@ -38,7 +39,7 @@ template <typename T> static T loop_items(std::vector<T> items, T cur, bool next
 mfk_state_t  mfk_state = MFK_STATE_EDIT;
 mfk_mode_t   mfk_mode = MFK_MIN_LEVEL;
 
-void mfk_update(int16_t diff, bool voice) {
+void mfk_update(int16_t diff, bool voice, bool show) {
     int32_t     i;
     char        *str;
     bool        b;
@@ -53,7 +54,8 @@ void mfk_update(int16_t diff, bool voice) {
                 i = limit(i + diff, S_MIN, S7);
                 subject_set_int(cfg_cur.band->grid.min.val, i);
             }
-            msg_update_text_fmt("#%3X Min level: %i dB", color, i);
+            if(show) msg_update_text_fmt("#%3X Min level: %i dB", color, i);
+            knobs_update_mfk("Min level: %i dB", i);
 
             if (diff) {
                 voice_say_int("Spectrum min level", i);
@@ -68,7 +70,8 @@ void mfk_update(int16_t diff, bool voice) {
                 i = limit(i + diff, S8, S9_40);
                 subject_set_int(cfg_cur.band->grid.max.val, i);
             }
-            msg_update_text_fmt("#%3X Max level: %i dB", color, i);
+            if(show) msg_update_text_fmt("#%3X Max level: %i dB", color, i);
+            knobs_update_mfk("Max level: %i dB", i);
 
             if (diff) {
                 voice_say_int("Spectrum max level", i);
@@ -83,7 +86,8 @@ void mfk_update(int16_t diff, bool voice) {
                 i = limit(i + diff, 1, 8);
                 subject_set_int(cfg_cur.zoom, i);
             }
-            msg_update_text_fmt("#%3X Spectrum zoom: x%i", color, i);
+            if(show) msg_update_text_fmt("#%3X Spectrum zoom: x%i", color, i);
+            knobs_update_mfk("Spectrum zoom: x%i", i);
 
             if (diff) {
                 voice_say_int("Spectrum zoom", i);
@@ -107,7 +111,8 @@ void mfk_update(int16_t diff, bool voice) {
 
                 dsp_set_spectrum_beta(params.spectrum_beta / 100.0f);
             }
-            msg_update_text_fmt("#%3X Spectrum beta: %i", color, params.spectrum_beta);
+            if(show) msg_update_text_fmt("#%3X Spectrum beta: %i", color, params.spectrum_beta);
+            knobs_update_mfk("Spectrum beta: %i", params.spectrum_beta);
 
             if (diff) {
                 voice_say_int("Spectrum beta", params.spectrum_beta);
@@ -122,7 +127,8 @@ void mfk_update(int16_t diff, bool voice) {
                 params.spectrum_filled = !params.spectrum_filled;
                 params_unlock(&params.dirty.spectrum_filled);
             }
-            msg_update_text_fmt("#%3X Spectrum fill: %s", color, params.spectrum_filled ? "On" : "Off");
+            if(show) msg_update_text_fmt("#%3X Spectrum fill: %s", color, params.spectrum_filled ? "On" : "Off");
+            knobs_update_mfk("Spectrum fill: %s", params.spectrum_filled ? "On" : "Off");
 
             if (diff) {
                 voice_say_bool("Spectrum fill", params.spectrum_filled);
@@ -137,7 +143,8 @@ void mfk_update(int16_t diff, bool voice) {
                 params.spectrum_peak = !params.spectrum_peak;
                 params_unlock(&params.dirty.spectrum_peak);
             }
-            msg_update_text_fmt("#%3X Spectrum peak: %s", color, params.spectrum_peak ? "On" : "Off");
+            if(show) msg_update_text_fmt("#%3X Spectrum peak: %s", color, params.spectrum_peak ? "On" : "Off");
+            knobs_update_mfk("Spectrum peak: %s", params.spectrum_peak ? "On" : "Off");
 
             if (diff) {
                 voice_say_bool("Spectrum peak", params.spectrum_peak);
@@ -160,7 +167,8 @@ void mfk_update(int16_t diff, bool voice) {
                 params.spectrum_peak_hold = i;
                 params_unlock(&params.dirty.spectrum_peak_hold);
             }
-            msg_update_text_fmt("#%3X Peak hold: %i s", color, params.spectrum_peak_hold / 1000);
+            if(show) msg_update_text_fmt("#%3X Peak hold: %i s", color, params.spectrum_peak_hold / 1000);
+            knobs_update_mfk("Peak hold: %i s", params.spectrum_peak_hold / 1000);
 
             if (diff) {
                 voice_say_int("Peak hold time", params.spectrum_peak_hold / 1000);
@@ -175,7 +183,8 @@ void mfk_update(int16_t diff, bool voice) {
                 i = clip(i + diff, 1, 8);
                 subject_set_int(cfg.comp.val, i);
             }
-            msg_update_text_fmt("#%3X Compressor ratio: %s", color, params_comp_str_get(i));
+            if(show) msg_update_text_fmt("#%3X Compressor ratio: %s", color, params_comp_str_get(i));
+            knobs_update_mfk("Compressor ratio: %s", params_comp_str_get(i));
 
             if (diff) {
                 if (i > 1) {
@@ -202,7 +211,8 @@ void mfk_update(int16_t diff, bool voice) {
                 params.spectrum_peak_speed = f;
                 params_unlock(&params.dirty.spectrum_peak_speed);
             }
-            msg_update_text_fmt("#%3X Peak speed: %.1f dB", color, params.spectrum_peak_speed);
+            if(show) msg_update_text_fmt("#%3X Peak speed: %.1f dB", color, params.spectrum_peak_speed);
+            knobs_update_mfk("Peak speed: %.1f dB", params.spectrum_peak_speed);
 
             if (diff) {
                 voice_say_float("Peak speed time", params.spectrum_peak_speed);
@@ -218,7 +228,8 @@ void mfk_update(int16_t diff, bool voice) {
                 i = clip(i + diff, 5, 50);
                 subject_set_int(cfg.key_speed.val, i);
             }
-            msg_update_text_fmt("#%3X Key speed: %i wpm", color, i);
+            if(show) msg_update_text_fmt("#%3X Key speed: %i wpm", color, i);
+            knobs_update_mfk("Key speed: %i wpm", i);
 
             if (diff) {
                 voice_say_int("CW key speed", i);
@@ -235,7 +246,8 @@ void mfk_update(int16_t diff, bool voice) {
                 subject_set_int(cfg.key_mode.val, i);
             }
             str = params_key_mode_str_get((x6100_key_mode_t)i);
-            msg_update_text_fmt("#%3X Key mode: %s", color, str);
+            if(show) msg_update_text_fmt("#%3X Key mode: %s", color, str);
+            knobs_update_mfk("Key mode: %s", str);
 
             if (diff) {
                 voice_say_text("CW key mode", str);
@@ -252,7 +264,8 @@ void mfk_update(int16_t diff, bool voice) {
                 subject_set_int(cfg.key_mode.val, i);
             }
             str = params_iambic_mode_str_ger((x6100_iambic_mode_t)i);
-            msg_update_text_fmt("#%3X Iambic mode: %s", color, str);
+            if(show) msg_update_text_fmt("#%3X Iambic mode: %s", color, str);
+            knobs_update_mfk("Iambic mode: %s", str);
 
             if (diff) {
                 voice_say_text("Iambic mode", str);
@@ -268,7 +281,8 @@ void mfk_update(int16_t diff, bool voice) {
                 i = clip(i + diff * 10, 400, 1200);
                 subject_set_int(cfg.key_tone.val, i);
             }
-            msg_update_text_fmt("#%3X Key tone: %i Hz", color, i);
+            if(show) msg_update_text_fmt("#%3X Key tone: %i Hz", color, i);
+            knobs_update_mfk("Key tone: %i Hz", i);
 
             if (diff) {
                 voice_say_int("CW key tone", i);
@@ -284,7 +298,8 @@ void mfk_update(int16_t diff, bool voice) {
                 i = clip(i + diff, 0, 32);
                 subject_set_int(cfg.key_vol.val, i);
             }
-            msg_update_text_fmt("#%3X Key volume: %i", color, i);
+            if(show) msg_update_text_fmt("#%3X Key volume: %i", color, i);
+            knobs_update_mfk("Key volume: %i", i);
 
             if (diff) {
                 voice_say_int("CW key volume level", i);
@@ -300,7 +315,8 @@ void mfk_update(int16_t diff, bool voice) {
                 b = !b;
                 subject_set_int(cfg.key_train.val, b);
             }
-            msg_update_text_fmt("#%3X Key train: %s", color, b ? "On" : "Off");
+            if(show) msg_update_text_fmt("#%3X Key train: %s", color, b ? "On" : "Off");
+            knobs_update_mfk("Key train: %s", b ? "On" : "Off");
 
             if (diff) {
                 voice_say_bool("CW key train", b);
@@ -316,7 +332,8 @@ void mfk_update(int16_t diff, bool voice) {
                 i = clip(i + diff * 10, 0, 1000);
                 subject_set_int(cfg.qsk_time.val, i);
             }
-            msg_update_text_fmt("#%3X QSK time: %i ms", color, i);
+            if(show) msg_update_text_fmt("#%3X QSK time: %i ms", color, i);
+            knobs_update_mfk("QSK time: %i ms", i);
 
             if (diff) {
                 voice_say_int("CW key QSK time", i);
@@ -332,7 +349,8 @@ void mfk_update(int16_t diff, bool voice) {
                 f = clip(f + diff * 0.1f, 2.5f, 4.5f);
                 subject_set_float(cfg.key_ratio.val, f);
             }
-            msg_update_text_fmt("#%3X Key ratio: %.1f", color, f);
+            if(show) msg_update_text_fmt("#%3X Key ratio: %.1f", color, f);
+            knobs_update_mfk("Key ratio: %.1f", f);
 
             if (diff) {
                 voice_say_float("CW key ratio", f);
@@ -344,7 +362,8 @@ void mfk_update(int16_t diff, bool voice) {
         case MFK_CHARGER:
             i = radio_change_charger(diff);
             str = params_charger_str_get((radio_charger_t)i);
-            msg_update_text_fmt("#%3X Charger: %s", color, str);
+            if(show) msg_update_text_fmt("#%3X Charger: %s", color, str);
+            knobs_update_mfk("Charger: %s", str);
 
             if (diff) {
                 voice_say_text("Charger mode", str);
@@ -362,7 +381,8 @@ void mfk_update(int16_t diff, bool voice) {
                     // radio_load_atu();
                     // info_atu_update();
                 }
-                msg_update_text_fmt("#%3X Antenna : %i", color, ant);
+                if(show) msg_update_text_fmt("#%3X Antenna : %i", color, ant);
+                knobs_update_mfk("Antenna : %i", ant);
 
                 if (diff) {
                     voice_say_int("Antenna", ant);
@@ -374,7 +394,8 @@ void mfk_update(int16_t diff, bool voice) {
 
         case MFK_RIT:
             i = radio_change_rit(diff);
-            msg_update_text_fmt("#%3X RIT: %c%i", color, i < 0 ? '-' : '+', abs(i));
+            if(show) msg_update_text_fmt("#%3X RIT: %c%i", color, i < 0 ? '-' : '+', abs(i));
+            knobs_update_mfk("RIT: %c%i", i < 0 ? '-' : '+', abs(i));
 
             if (diff) {
                 voice_say_int("RIT", i);
@@ -385,7 +406,8 @@ void mfk_update(int16_t diff, bool voice) {
 
         case MFK_XIT:
             i = radio_change_xit(diff);
-            msg_update_text_fmt("#%3X XIT: %c%i", color, i < 0 ? '-' : '+', abs(i));
+            if(show) msg_update_text_fmt("#%3X XIT: %c%i", color, i < 0 ? '-' : '+', abs(i));
+            knobs_update_mfk("XIT: %c%i", i < 0 ? '-' : '+', abs(i));
 
             if (diff) {
                 voice_say_int("XIT", i);
@@ -401,7 +423,8 @@ void mfk_update(int16_t diff, bool voice) {
                 b = !b;
                 subject_set_int(cfg.dnf.val, b);
             }
-            msg_update_text_fmt("#%3X DNF: %s", color, b ? "On" : "Off");
+            if(show) msg_update_text_fmt("#%3X DNF: %s", color, b ? "On" : "Off");
+            knobs_update_mfk("DNF: %s", b ? "On" : "Off");
 
             if (diff) {
                 voice_say_bool("DNF", b);
@@ -417,7 +440,8 @@ void mfk_update(int16_t diff, bool voice) {
                 i = limit(i + diff * 50, 100, 3000);
                 subject_set_int(cfg.dnf_center.val, i);
             }
-            msg_update_text_fmt("#%3X DNF center: %i Hz", color, i);
+            if(show) msg_update_text_fmt("#%3X DNF center: %i Hz", color, i);
+            knobs_update_mfk("DNF center: %i Hz", i);
 
             if (diff) {
                 voice_say_int("DNF center frequency", i);
@@ -433,7 +457,8 @@ void mfk_update(int16_t diff, bool voice) {
                 i = limit(i + diff * 5, 10, 100);
                 subject_set_int(cfg.dnf_width.val, i);
             }
-            msg_update_text_fmt("#%3X DNF width: %i Hz", color, i);
+            if(show) msg_update_text_fmt("#%3X DNF width: %i Hz", color, i);
+            knobs_update_mfk("DNF width: %i Hz", i);
 
             if (diff) {
                 voice_say_int("DNF width", i);
@@ -449,7 +474,8 @@ void mfk_update(int16_t diff, bool voice) {
                 b = !b;
                 subject_set_int(cfg.nb.val, b);
             }
-            msg_update_text_fmt("#%3X NB: %s", color, b ? "On" : "Off");
+            if(show) msg_update_text_fmt("#%3X NB: %s", color, b ? "On" : "Off");
+            knobs_update_mfk("NB: %s", b ? "On" : "Off");
 
             if (diff) {
                 voice_say_bool("NB", b);
@@ -466,7 +492,8 @@ void mfk_update(int16_t diff, bool voice) {
                 i = limit(i + diff * 5, 0, 100);
                 subject_set_int(cfg.nb_level.val, i);
             }
-            msg_update_text_fmt("#%3X NB level: %i", color, i);
+            if(show) msg_update_text_fmt("#%3X NB level: %i", color, i);
+            knobs_update_mfk("NB level: %i", i);
 
             if (diff) {
                 voice_say_int("NB level", i);
@@ -483,7 +510,8 @@ void mfk_update(int16_t diff, bool voice) {
                 i = limit(i + diff * 5, 0, 100);
                 subject_set_int(cfg.nb_width.val, i);
             }
-            msg_update_text_fmt("#%3X NB width: %i Hz", color, i);
+            if(show) msg_update_text_fmt("#%3X NB width: %i Hz", color, i);
+            knobs_update_mfk("NB width: %i Hz", i);
 
             if (diff) {
                 voice_say_int("NB width", i);
@@ -499,7 +527,8 @@ void mfk_update(int16_t diff, bool voice) {
                 b = !b;
                 subject_set_int(cfg.nr.val, b);
             }
-            msg_update_text_fmt("#%3X NR: %s", color, b ? "On" : "Off");
+            if(show) msg_update_text_fmt("#%3X NR: %s", color, b ? "On" : "Off");
+            knobs_update_mfk("NR: %s", b ? "On" : "Off");
 
             if (diff) {
                 voice_say_bool("NR", b);
@@ -516,7 +545,8 @@ void mfk_update(int16_t diff, bool voice) {
                 i = limit(i + diff * 5, 0, 60);
                 subject_set_int(cfg.nr_level.val, i);
             }
-            msg_update_text_fmt("#%3X NR level: %i", color, i);
+            if(show) msg_update_text_fmt("#%3X NR level: %i", color, i);
+            knobs_update_mfk("NR level: %i", i);
 
             if (diff) {
                 voice_say_int("NR level", i);
@@ -532,7 +562,8 @@ void mfk_update(int16_t diff, bool voice) {
                 b = !b;
                 subject_set_int(cfg.agc_hang.val, b);
             }
-            msg_update_text_fmt("#%3X AGC hang: %s", color, b ? "On" : "Off");
+            if(show) msg_update_text_fmt("#%3X AGC hang: %s", color, b ? "On" : "Off");
+            knobs_update_mfk("AGC hang: %s", b ? "On" : "Off");
 
             if (diff) {
                 voice_say_bool("Auto gain hang", b);
@@ -549,7 +580,8 @@ void mfk_update(int16_t diff, bool voice) {
                 i = limit(i + diff, -100, 0);
                 subject_set_int(cfg.agc_knee.val, i);
             }
-            msg_update_text_fmt("#%3X AGC knee: %i dB", color, i);
+            if(show) msg_update_text_fmt("#%3X AGC knee: %i dB", color, i);
+            knobs_update_mfk("AGC knee: %i dB", i);
 
             if (diff) {
                 voice_say_int("Auto gain knee level", i);
@@ -566,7 +598,8 @@ void mfk_update(int16_t diff, bool voice) {
                 i = limit(i + diff, 0, 10);
                 subject_set_int(cfg.agc_slope.val, i);
             }
-            msg_update_text_fmt("#%3X AGC slope: %i dB", color, i);
+            if(show) msg_update_text_fmt("#%3X AGC slope: %i dB", color, i);
+            knobs_update_mfk("AGC slope: %i dB", i);
 
             if (diff) {
                 voice_say_int("Auto gain slope level", i);
@@ -582,7 +615,8 @@ void mfk_update(int16_t diff, bool voice) {
                 b = !b;
                 subject_set_int(cfg.cw_decoder.val, b);
             }
-            msg_update_text_fmt("#%3X CW decoder: %s", color, b ? "On" : "Off");
+            if(show) msg_update_text_fmt("#%3X CW decoder: %s", color, b ? "On" : "Off");
+            knobs_update_mfk("CW decoder: %s", b ? "On" : "Off");
 
             if (diff) {
                 voice_say_bool("CW decoder", b);
@@ -598,7 +632,8 @@ void mfk_update(int16_t diff, bool voice) {
                 b = !b;
                 subject_set_int(cfg.cw_tune.val, b);
             }
-            msg_update_text_fmt("#%3X CW tune: %s", color, b ? "On" : "Off");
+            if(show) msg_update_text_fmt("#%3X CW tune: %s", color, b ? "On" : "Off");
+            knobs_update_mfk("CW tune: %s", b ? "On" : "Off");
 
             if (diff) {
                 voice_say_bool("CW tune", b);
@@ -614,7 +649,8 @@ void mfk_update(int16_t diff, bool voice) {
                 f = clip(f + diff * 0.1f, 3.0f, 30.0f);
                 subject_set_float(cfg.cw_decoder_snr.val, f);
             }
-            msg_update_text_fmt("#%3X CW decoder SNR: %.1f dB", color, f);
+            if(show) msg_update_text_fmt("#%3X CW decoder SNR: %.1f dB", color, f);
+            knobs_update_mfk("CW decoder SNR: %.1f dB", f);
 
             if (diff) {
                 voice_say_float("CW decoder SNR level", f);
@@ -630,7 +666,8 @@ void mfk_update(int16_t diff, bool voice) {
                 subject_set_float(cfg.cw_decoder_peak_beta.val, f);
             }
             // f = cw_change_peak_beta(diff);
-            msg_update_text_fmt("#%3X CW decoder peak beta: %.2f", color, f);
+            if(show) msg_update_text_fmt("#%3X CW decoder peak beta: %.2f", color, f);
+            knobs_update_mfk("CW decoder peak beta: %.2f", f);
 
             if (diff) {
                 voice_say_float("CW decoder peak beta", f);
@@ -646,7 +683,8 @@ void mfk_update(int16_t diff, bool voice) {
                 subject_set_float(cfg.cw_decoder_noise_beta.val, f);
             }
             // f = cw_change_noise_beta(diff);
-            msg_update_text_fmt("#%3X CW decoder noise beta: %.2f", color, f);
+            if(show) msg_update_text_fmt("#%3X CW decoder noise beta: %.2f", color, f);
+            knobs_update_mfk("CW decoder noise beta: %.2f", f);
 
             if (diff) {
                 voice_say_float("CW decoder noise beta", f);
@@ -657,7 +695,8 @@ void mfk_update(int16_t diff, bool voice) {
 
         case MFK_RTTY_RATE:
             f = rtty_change_rate(diff);
-            msg_update_text_fmt("#%3X RTTY rate: %.2f", color, f);
+            if(show) msg_update_text_fmt("#%3X RTTY rate: %.2f", color, f);
+            knobs_update_mfk("RTTY rate: %.2f", f);
 
             if (diff) {
                 voice_say_float2("Teletype rate", f);
@@ -668,7 +707,8 @@ void mfk_update(int16_t diff, bool voice) {
 
         case MFK_RTTY_SHIFT:
             i = rtty_change_shift(diff);
-            msg_update_text_fmt("#%3X RTTY shift: %i Hz", color, i);
+            if(show) msg_update_text_fmt("#%3X RTTY shift: %i Hz", color, i);
+            knobs_update_mfk("RTTY shift: %i Hz", i);
 
             if (diff) {
                 voice_say_int("Teletype frequency shift", i);
@@ -679,7 +719,8 @@ void mfk_update(int16_t diff, bool voice) {
 
         case MFK_RTTY_CENTER:
             i = rtty_change_center(diff);
-            msg_update_text_fmt("#%3X RTTY center: %i Hz", color, i);
+            if(show) msg_update_text_fmt("#%3X RTTY center: %i Hz", color, i);
+            knobs_update_mfk("RTTY center: %i Hz", i);
 
             if (diff) {
                 voice_say_int("Teletype frequency center", i);
@@ -690,7 +731,8 @@ void mfk_update(int16_t diff, bool voice) {
 
         case MFK_RTTY_REVERSE:
             b = rtty_change_reverse(diff);
-            msg_update_text_fmt("#%3X RTTY reverse: %s", color, b ? "On" : "Off");
+            if(show) msg_update_text_fmt("#%3X RTTY reverse: %s", color, b ? "On" : "Off");
+            knobs_update_mfk("RTTY reverse: %s", b ? "On" : "Off");
 
             if (diff) {
                 voice_say_bool("Teletype reverse", b);
@@ -706,7 +748,7 @@ void mfk_update(int16_t diff, bool voice) {
 
 void mfk_change_mode(int16_t dir) {
     mfk_mode = (mfk_mode_t)loop_modes(dir, mfk_mode, params.mfk_modes, MFK_LAST-1);
-    mfk_update(0, true);
+    mfk_update(0, true, true);
 }
 
 void mfk_set_mode(mfk_mode_t mode) {

--- a/src/mfk.h
+++ b/src/mfk.h
@@ -78,7 +78,7 @@ typedef enum {
 
 extern mfk_state_t  mfk_state;
 
-void mfk_update(int16_t diff, bool voice);
+void mfk_update(int16_t diff, bool voice, bool show);
 void mfk_change_mode(int16_t dir);
 void mfk_set_mode(mfk_mode_t mode);
 

--- a/src/styles.c
+++ b/src/styles.c
@@ -93,6 +93,7 @@ lv_style_t  btn_disabled_style;
 lv_style_t  msg_style;
 lv_style_t  msg_tiny_style;
 lv_style_t  clock_style;
+lv_style_t  knobs_style;
 lv_style_t  info_style;
 lv_style_t  info_row_style;
 lv_style_t  info_item_style;
@@ -245,6 +246,12 @@ void styles_init(themes_t theme) {
     lv_style_set_radius(&clock_style, 0);
     lv_style_set_bg_img_opa(&clock_style, LV_OPA_COVER);
 
+    /* Knobs */
+    lv_style_init(&knobs_style);
+    lv_style_set_text_color(&knobs_style, lv_color_white());
+    lv_style_set_radius(&knobs_style, 0);
+    lv_style_set_bg_img_opa(&knobs_style, LV_OPA_COVER);
+
     /* Left info */
     lv_style_init(&info_style);
     lv_style_set_align(&info_style, LV_ALIGN_TOP_LEFT);
@@ -321,6 +328,8 @@ static void setup_theme_legacy() {
     lv_style_set_bg_img_src(&clock_style, PATH "images/top_short.bin");
     lv_style_set_width(&clock_style, 206);
     lv_style_set_height(&clock_style, 61);
+    /* Knobs */
+    // lv_style_set_bg_img_src(&knobs_style, PATH "images/top_short.bin");
     /* Info */
     lv_style_set_bg_img_src(&info_style, PATH "images/top_short.bin");
     lv_style_set_width(&info_style, 206);
@@ -353,6 +362,8 @@ static void setup_theme_simple() {
     lv_style_set_bg_img_src(&clock_style, PATH "images/top_short_dark.bin");
     lv_style_set_width(&clock_style, 209);
     lv_style_set_height(&clock_style, 61);
+    /* Knobs */
+    // lv_style_set_bg_img_src(&knobs_style, PATH "images/top_short_dark.bin");
     /* Info */
     lv_style_set_bg_img_src(&info_style, PATH "images/top_short_dark.bin");
     lv_style_set_width(&info_style, 209);

--- a/src/styles.h
+++ b/src/styles.h
@@ -41,6 +41,7 @@ extern lv_style_t   btn_disabled_style;
 extern lv_style_t   msg_style;
 extern lv_style_t   msg_tiny_style;
 extern lv_style_t   clock_style;
+extern lv_style_t   knobs_style;
 extern lv_style_t   info_style;
 extern lv_style_t   info_row_style;
 extern lv_style_t   info_item_style;

--- a/src/vol.c
+++ b/src/vol.c
@@ -15,10 +15,11 @@
 #include "voice.h"
 #include "util.h"
 #include "cfg/mode.h"
+#include "knobs.h"
 
 static vol_mode_t   vol_mode = VOL_VOL;
 
-void vol_update(int16_t diff, bool voice) {
+void vol_update(int16_t diff, bool voice, bool show) {
     int32_t     x;
     float       f;
     char        *s;
@@ -27,10 +28,14 @@ void vol_update(int16_t diff, bool voice) {
 
     uint32_t    color = vol->mode == VOL_EDIT ? 0xFFFFFF : 0xBBBBBB;
 
+    //test
+    knobs_update_vol("UPDATE!! 2");
+
     switch (vol_mode) {
         case VOL_VOL:
             x = radio_change_vol(diff);
-            msg_update_text_fmt("#%3X Volume: %i", color, x);
+            if(show) msg_update_text_fmt("#%3X Volume: %i", color, x);
+            knobs_update_vol("Volume: %i", x);
 
             if (diff) {
                 voice_say_int("Audio level", x);
@@ -43,7 +48,8 @@ void vol_update(int16_t diff, bool voice) {
             x = subject_get_int(cfg_cur.band->rfg.val);
             x = limit(x + diff, 0, 100);
             subject_set_int(cfg_cur.band->rfg.val, x);
-            msg_update_text_fmt("#%3X RF gain: %i", color, x);
+            if(show) msg_update_text_fmt("#%3X RF gain: %i", color, x);
+            knobs_update_vol("RF gain: %i", x);
 
             if (diff) {
                 voice_say_int("RF gain", x);
@@ -56,7 +62,8 @@ void vol_update(int16_t diff, bool voice) {
             x = subject_get_int(cfg.sql.val);
             x = limit(x + diff, 0, 100);
             subject_set_int(cfg.sql.val, x);
-            msg_update_text_fmt("#%3X Voice SQL: %i", color, x);
+            if(show) msg_update_text_fmt("#%3X Voice SQL: %i", color, x);
+            knobs_update_vol("Voice SQL: %i", x);
 
             if (diff) {
                 voice_say_int("Squelch level %i", x);
@@ -73,7 +80,8 @@ void vol_update(int16_t diff, bool voice) {
                 x = cfg_mode_set_low_filter(x);
             }
             // x = radio_change_filter_low(freq);
-            msg_update_text_fmt("#%3X Filter low: %i Hz", color, x);
+            if(show) msg_update_text_fmt("#%3X Filter low: %i Hz", color, x);
+            knobs_update_vol("Filter low: %i Hz", x);
 
             if (diff) {
                 voice_delay_say_text_fmt("%i", x);
@@ -100,7 +108,8 @@ void vol_update(int16_t diff, bool voice) {
                 x = cfg_mode_set_high_filter(x);
             }
             // x = radio_change_filter_high(freq);
-            msg_update_text_fmt("#%3X Filter high: %i Hz", color, x);
+            if(show) msg_update_text_fmt("#%3X Filter high: %i Hz", color, x);
+            knobs_update_vol("Filter high: %i Hz", x);
 
             if (diff) {
                 voice_say_int("High filter limit", x);
@@ -115,7 +124,8 @@ void vol_update(int16_t diff, bool voice) {
                 bw = align_int(bw + diff * 20, 20);
                 subject_set_int(cfg_cur.filter.bw, bw);
             }
-            msg_update_text_fmt("#%3X Filter bw: %i Hz", color, bw);
+            if(show) msg_update_text_fmt("#%3X Filter bw: %i Hz", color, bw);
+            knobs_update_vol("Filter bw: %i Hz", bw);
 
             if (diff) {
                 voice_delay_say_text_fmt("%i", bw);
@@ -130,7 +140,8 @@ void vol_update(int16_t diff, bool voice) {
             f = LV_MIN(10.0f, f);
             f = LV_MAX(0.1f, f);
             subject_set_float(cfg.pwr.val, f);
-            msg_update_text_fmt("#%3X Power: %0.1f W", color, f);
+            if(show) msg_update_text_fmt("#%3X Power: %0.1f W", color, f);
+            knobs_update_vol("Power: %0.1f W", f);
 
             if (diff) {
                 voice_say_float("Transmit power", f);
@@ -142,7 +153,8 @@ void vol_update(int16_t diff, bool voice) {
         case VOL_MIC:
             x = radio_change_mic(diff);
             s = params_mic_str_get(x);
-            msg_update_text_fmt("#%3X MIC: %s", color, s);
+            if(show) msg_update_text_fmt("#%3X MIC: %s", color, s);
+            knobs_update_vol("MIC: %s", s);
 
             if (diff) {
                 voice_say_text("Mic selector", s);
@@ -153,7 +165,8 @@ void vol_update(int16_t diff, bool voice) {
 
         case VOL_HMIC:
             x = radio_change_hmic(diff);
-            msg_update_text_fmt("#%3X H-MIC gain: %i", color, x);
+            if(show) msg_update_text_fmt("#%3X H-MIC gain: %i", color, x);
+            knobs_update_vol("H-MIC gain: %i", x);
 
             if (diff) {
                 voice_say_int("Hand microphone gain", x);
@@ -164,7 +177,8 @@ void vol_update(int16_t diff, bool voice) {
 
         case VOL_IMIC:
             x = radio_change_imic(diff);
-            msg_update_text_fmt("#%3X I-MIC gain: %i", color, x);
+            if(show) msg_update_text_fmt("#%3X I-MIC gain: %i", color, x);
+            knobs_update_vol("I-MIC gain: %i", x);
 
             if (diff) {
                 voice_say_int("Internal microphone gain", x);
@@ -175,7 +189,8 @@ void vol_update(int16_t diff, bool voice) {
 
         case VOL_MONI:
             x = radio_change_moni(diff);
-            msg_update_text_fmt("#%3X Moni level: %i", color, x);
+            if(show) msg_update_text_fmt("#%3X Moni level: %i", color, x);
+            knobs_update_vol("Moni level: %i", x);
 
             if (diff) {
                 voice_say_int("Monitor level", x);
@@ -186,7 +201,8 @@ void vol_update(int16_t diff, bool voice) {
 
         case VOL_VOICE_LANG:
             s = (char *)voice_change(diff);
-            msg_update_text_fmt("#%3X Voice: %s", color, s);
+            if(show) msg_update_text_fmt("#%3X Voice: %s", color, s);
+            knobs_update_vol("Voice: %s", s);
 
             if (diff) {
                 voice_say_lang();
@@ -197,7 +213,8 @@ void vol_update(int16_t diff, bool voice) {
 
         case VOL_VOICE_RATE:
             x = params_uint8_change(&params.voice_rate, diff);
-            msg_update_text_fmt("#%3X Voice rate: %i", color, x);
+            if(show) msg_update_text_fmt("#%3X Voice rate: %i", color, x);
+            knobs_update_vol("Voice rate: %i", x);
 
             if (diff == 0 && voice) {
                 voice_say_text_fmt(params.voice_rate.voice);
@@ -206,7 +223,8 @@ void vol_update(int16_t diff, bool voice) {
 
         case VOL_VOICE_PITCH:
             x = params_uint8_change(&params.voice_pitch, diff);
-            msg_update_text_fmt("#%3X Voice pitch: %i", color, x);
+            if(show) msg_update_text_fmt("#%3X Voice pitch: %i", color, x);
+            knobs_update_vol("Voice pitch: %i", x);
 
             if (diff == 0 && voice) {
                 voice_say_text_fmt(params.voice_pitch.voice);
@@ -215,7 +233,8 @@ void vol_update(int16_t diff, bool voice) {
 
         case VOL_VOICE_VOLUME:
             x = params_uint8_change(&params.voice_volume, diff);
-            msg_update_text_fmt("#%3X Voice volume: %i", color, x);
+            if(show) msg_update_text_fmt("#%3X Voice volume: %i", color, x);
+            knobs_update_vol("Voice volume: %i", x);
 
             if (diff == 0 && voice) {
                 voice_say_text_fmt(params.voice_volume.voice);
@@ -229,7 +248,7 @@ void vol_update(int16_t diff, bool voice) {
 
 void vol_change_mode(int16_t dir) {
     vol_mode = loop_modes(dir, vol_mode, params.vol_modes, VOL_LAST-1);
-    vol_update(0, true);
+    vol_update(0, true, true);
 }
 
 void vol_set_mode(vol_mode_t mode) {

--- a/src/vol.h
+++ b/src/vol.h
@@ -32,6 +32,6 @@ typedef enum {
     VOL_LAST
 } vol_mode_t;
 
-void vol_update(int16_t diff, bool voice);
+void vol_update(int16_t diff, bool voice, bool show);
 void vol_change_mode(int16_t dir);
 void vol_set_mode(vol_mode_t mode);


### PR DESCRIPTION
I added it for my wife's request, SQ5FOX. There is an option to preview what option is assigned to which knob. There is also an option to click a knob to see what setting is currently assigned to it. But seeing it constantly on the main screen is also a good option. 

There is no option for disabling this. But could be added as an additional feature. But I want to see if I will be accepted as a contributor.

Screenshot of  feature:
![2025-05-24 14-49-12](https://github.com/user-attachments/assets/9390a133-78b5-483b-8c12-92a2e1a8cf4e)

73 de SQ5FOX. 

I have plans to be contributor of this project. ADIF viewer, editor and logger also would be great. I am planning to implement such a thing.