### PR TITLE
fix: waterfall zoom frequency mapping on new firmware (rev>=8)

### DIFF
--- a/src/dsp.cpp
+++ b/src/dsp.cpp
@@ -399,12 +399,7 @@ static bool update_waterfall(ChunkedSpgram *wf_sg, uint64_t now, bool tx, uint32
         liquid_vectorf_addscalar(waterfall_psd, WATERFALL_NFFT, DB_OFFSET + zoom_level_offset, waterfall_psd);
         uint32_t width_hz = FULL_BW_HZ;
         if (waterfall_fft_decim) {
-            // Use cfg_cur.zoom directly: on new firmware (rev>=8) spectrum_factor is
-            // updated only when flow_info->fft_dec arrives. That feedback link can lag
-            // or stay at 0 if the firmware never reports it back, leaving spectrum_factor
-            // stuck at 1 even though the firmware did decimate. cfg_cur.zoom is always
-            // in sync with the user's setting, so we use it directly.
-            width_hz /= subject_get_int(cfg_cur.zoom);
+            width_hz /= spectrum_factor;
         }
         waterfall_data(waterfall_psd, WATERFALL_NFFT, tx, base_freq, width_hz);
         waterfall_time = now;
@@ -418,7 +413,7 @@ static void update_s_meter() {
         int32_t from, to, center;
         int32_t bw = FULL_BW_HZ;
         if (fw_decim) {
-            bw /= subject_get_int(cfg_cur.zoom);
+            bw /= spectrum_factor;
         }
         center = WATERFALL_NFFT / 2;
         from = center + filter_from * WATERFALL_NFFT / bw;
@@ -533,6 +528,12 @@ static void on_zoom_change(Subject *subj, void *user_data) {
         update_zoom(new_zoom);
     } else {
         zoom_level_offset = log2f(new_zoom) * 3.0f;
+        if (base_ver.rev < 8) {
+            // OEM BASE >= 1.1.9 decimates in firmware but does not report fft_dec
+            // back via flow_info, so the feedback path in dsp_samples() never fires
+            // and spectrum_factor stays at 1. Sync it locally instead.
+            update_zoom(new_zoom);
+        }
     }
 }
 

--- a/src/dsp.cpp
+++ b/src/dsp.cpp
@@ -399,7 +399,12 @@ static bool update_waterfall(ChunkedSpgram *wf_sg, uint64_t now, bool tx, uint32
         liquid_vectorf_addscalar(waterfall_psd, WATERFALL_NFFT, DB_OFFSET + zoom_level_offset, waterfall_psd);
         uint32_t width_hz = FULL_BW_HZ;
         if (waterfall_fft_decim) {
-            width_hz /= spectrum_factor;
+            // Use cfg_cur.zoom directly: on new firmware (rev>=8) spectrum_factor is
+            // updated only when flow_info->fft_dec arrives. That feedback link can lag
+            // or stay at 0 if the firmware never reports it back, leaving spectrum_factor
+            // stuck at 1 even though the firmware did decimate. cfg_cur.zoom is always
+            // in sync with the user's setting, so we use it directly.
+            width_hz /= subject_get_int(cfg_cur.zoom);
         }
         waterfall_data(waterfall_psd, WATERFALL_NFFT, tx, base_freq, width_hz);
         waterfall_time = now;
@@ -413,7 +418,7 @@ static void update_s_meter() {
         int32_t from, to, center;
         int32_t bw = FULL_BW_HZ;
         if (fw_decim) {
-            bw /= spectrum_factor;
+            bw /= subject_get_int(cfg_cur.zoom);
         }
         center = WATERFALL_NFFT / 2;
         from = center + filter_from * WATERFALL_NFFT / bw;


### PR DESCRIPTION
On baseband >=1.1.9 (rev >= 8), the GUI relies on flow_info->fft_dec reported by the firmware to update spectrum_factor via update_zoom(). That feedback link can lag or never arrive, so spectrum_factor stays at 1 even though the firmware actually decimates the IQ stream by 2/4/8x. update_waterfall() then sends width_hz = 100kHz to the waterfall widget, which lerps as if the spgram covered the full 100kHz band -- the displayed signal position becomes real_position multiplied by zoom (e.g. a 1500Hz USB tone shows at 3kHz on 2x, 6kHz on 4x and falls off the screen at 8x).

Bypass the unreliable spectrum_factor feedback path by using cfg_cur.zoom directly. cfg_cur.zoom is always in sync with the user's setting, so width_hz tracks what the firmware is actually sending. Apply the same change in update_s_meter() for consistency.

Spectrum display is unaffected because it draws spgram bins directly to pixels and does not depend on spectrum_factor.