### PR TITLE
FT8 Enhancement

### DIFF
--- a/src/cfg/cfg.c
+++ b/src/cfg/cfg.c
@@ -407,7 +407,6 @@ static int init_params_cfg(sqlite3 *db) {
     fill_cfg_item_int(&cfg.ft8_auto, subject_create_int(true), "ft8_auto");
     fill_cfg_item_int(&cfg.ft8_auto_dnf, subject_create_int(true), "ft8_auto_dnf");
     fill_cfg_item_int(&cfg.ft8_xit, subject_create_int(true), "ft8_xit");
-    fill_cfg_item_int(&cfg.ft8_omit_cq_qth, subject_create_int(false), "ft8_omit_cq_qth");
     fill_cfg_item_int(&cfg.ft8_hold_freq, subject_create_int(true), "ft8_hold_freq");
     fill_cfg_item_int(&cfg.ft8_max_repeats, subject_create_int(6), "ft8_max_repeats");
 

--- a/src/cfg/cfg.c
+++ b/src/cfg/cfg.c
@@ -405,6 +405,9 @@ static int init_params_cfg(sqlite3 *db) {
     fill_cfg_item_int(&cfg.ft8_show_all, subject_create_int(true), "ft8_show_all");
     fill_cfg_item_int(&cfg.ft8_protocol, subject_create_int(FTX_PROTOCOL_FT8), "ft8_protocol");
     fill_cfg_item_int(&cfg.ft8_auto, subject_create_int(true), "ft8_auto");
+    fill_cfg_item_int(&cfg.ft8_auto_dnf, subject_create_int(true), "ft8_auto_dnf");
+    fill_cfg_item_int(&cfg.ft8_xit, subject_create_int(true), "ft8_xit");
+    fill_cfg_item_int(&cfg.ft8_omit_cq_qth, subject_create_int(false), "ft8_omit_cq_qth");
     fill_cfg_item_int(&cfg.ft8_hold_freq, subject_create_int(true), "ft8_hold_freq");
     fill_cfg_item_int(&cfg.ft8_max_repeats, subject_create_int(6), "ft8_max_repeats");
 

--- a/src/cfg/cfg.h
+++ b/src/cfg/cfg.h
@@ -163,6 +163,9 @@ typedef struct {
     cfg_item_t ft8_show_all;
     cfg_item_t ft8_protocol;
     cfg_item_t ft8_auto;
+    cfg_item_t ft8_auto_dnf;
+    cfg_item_t ft8_xit;
+    cfg_item_t ft8_omit_cq_qth;
     cfg_item_t ft8_hold_freq;
     cfg_item_t ft8_max_repeats;
 } cfg_t;

--- a/src/cfg/cfg.h
+++ b/src/cfg/cfg.h
@@ -165,7 +165,6 @@ typedef struct {
     cfg_item_t ft8_auto;
     cfg_item_t ft8_auto_dnf;
     cfg_item_t ft8_xit;
-    cfg_item_t ft8_omit_cq_qth;
     cfg_item_t ft8_hold_freq;
     cfg_item_t ft8_max_repeats;
 } cfg_t;

--- a/src/dialog_ft8.c
+++ b/src/dialog_ft8.c
@@ -1530,8 +1530,7 @@ static bool get_time_slot(struct timespec now, float *sec_since_start) {
  */
 static void make_cq_msg(const char *callsign, const char *qth, const char *cq_mod, char *text) {
     cq_make_message(callsign, qth, cq_mod,
-                    text, FTX_MAX_MESSAGE_LENGTH,
-                    subject_get_int(cfg.ft8_omit_cq_qth.val));
+                    text, FTX_MAX_MESSAGE_LENGTH);
 }
 
 /* Bridge to ft8/tx_worker.c - the actual TX play loop and ALC-driven gain

--- a/src/dialog_ft8.c
+++ b/src/dialog_ft8.c
@@ -508,11 +508,15 @@ static void on_psd_cb(const float *psd, uint16_t nfft, float sec_since_slot_star
         push.add_marker = true;
     }
 
-    /* Auto DNF. */
+    /* Auto DNF: compute frame_ts as the wall-clock time of this PSD frame
+     * (slot_start + sec_since_slot_start), not the bare slot boundary.
+     * The PSD represents audio accumulated since the last spgramcf_reset,
+     * which happened at approximately this wall-clock time. */
     if (s_auto_dnf && state == RX_PROCESS) {
         struct timespec frame_ts;
-        frame_ts.tv_sec  = (time_t)info->slot_start;
-        frame_ts.tv_nsec = 0;
+        double frame_time = (double)info->slot_start + (double)sec_since_slot_start;
+        frame_ts.tv_sec  = (time_t)frame_time;
+        frame_ts.tv_nsec = (long)((frame_time - (double)frame_ts.tv_sec) * 1.0e9);
         float dummy_sec;
         bool have_tx_msg    = tx_msg.msg[0] != '\0';
         bool is_our_tx_slot = (subject_get_int(tx_enabled) && have_tx_msg &&

--- a/src/dialog_ft8.c
+++ b/src/dialog_ft8.c
@@ -28,6 +28,7 @@
 #include "recorder.h"
 #include "tx_info.h"
 #include "textarea_window.h"
+#include "dsp.h"
 
 #include "widgets/lv_waterfall.h"
 #include "widgets/lv_finder.h"
@@ -45,9 +46,13 @@
 #include <math.h>
 #include <time.h>
 #include <sys/time.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <pthread.h>
+#include <stdatomic.h>
 #include <errno.h>
 #include <ctype.h>
+#include <stdarg.h>
 
 #define DECIM           6
 #define SAMPLE_RATE     (AUDIO_CAPTURE_RATE / DECIM)
@@ -56,7 +61,7 @@
 
 #define UNKNOWN_SNR     99
 
-#define MAX_PWR         5.0f
+#define MAX_PWR         10.0f
 
 #define FT8_WIDTH_HZ    50
 #define FT4_WIDTH_HZ    83
@@ -64,7 +69,19 @@
 #define MAX_TABLE_MSG   512
 #define CLEAN_N_ROWS    64
 
-#define MAX_TX_START_DELAY 1.5f
+/* Max unseen candidates to keep per slot to avoid unbounded memory growth */
+#define MAX_UNSEEN 100
+
+/*
+ * FT8 late-start TX:
+ * - Allow starting TX in the current slot up to 5 seconds.
+ * - If TX starts late, crop the beginning so the burst ends at 14.5s.
+ *
+ * Keep FT4 behavior unchanged.
+ */
+#define MAX_TX_START_DELAY 5.0f
+#define MAX_TX_START_DELAY_FT4 1.5f
+#define FT8_TX_END_SEC 14.5f
 
 #define WAIT_SYNC_TEXT "Wait sync"
 
@@ -75,42 +92,69 @@ typedef enum {
     TX_PROCESS,
 } ft8_state_t;
 
-typedef enum {
-    CELL_RX_INFO = 0,
-    CELL_RX_MSG,
-    CELL_RX_CQ,
-    CELL_RX_TO_ME,
-    CELL_TX_MSG
-} ft8_cell_type_t;
+/* ft8_cell_type_t / cell_data_t / table_view_* live in ft8/table_view.h.
+ * slot_info_t / ft8_log_* live in ft8/ft8_log.h. */
+#include "ft8/table_view.h"
+#include "ft8/ft8_log.h"
 
+static bool get_time_slot(struct timespec now, float *sec_since_start);
 
-/**
- * LVGL cell user data
- */
-typedef struct {
-    ft8_cell_type_t cell_type;
-    int16_t         dist;
-    bool            odd;
-    ftx_msg_meta_t  meta;
-    char            text[64];
+static time_t ft8_get_current_slot_start(void) {
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME, &now);
 
-    qso_log_search_worked_t       worked_type;
-} cell_data_t;
+    float sec_since_slot_start = 0.0f;
+    (void)get_time_slot(now, &sec_since_slot_start);
 
-
-typedef struct {
-    bool odd;
-    bool answer_generated;
-} slot_info_t;
+    double now_f = (double)now.tv_sec + (double)now.tv_nsec / 1.0e9;
+    double slot_start_f = now_f - (double)sec_since_slot_start;
+    return (time_t)slot_start_f;
+}
 
 static ft8_state_t state = RX_PROCESS;
 static Subject    *tx_enabled;
 static Subject    *cq_enabled;
 static bool        tx_time_slot;
+static bool        cq_paused_for_qso = false;
+/* AutoSel recovery mode: if a non-CQ QSO runs out of TX repeats and leaves a
+ * current QSO active (no timeout), allow AutoSel to start a new QSO by
+ * resetting the old one only after a new candidate is picked.
+ */
+static bool        autosel_recover_mode = false;
+
+/* After TX repeats are exhausted in a QSO, we keep the current QSO (no timeout),
+ * but allow higher-priority actions (reply to someone calling us, AutoSel).
+ */
+static bool        qso_tx_exhausted = false;
+
+/* Best-effort tracking of current QSO remote callsign (used to detect "other caller"). */
+static char        qso_active_call[16] = {0};
+
+/* True when current QSO was started by AutoSel (not manual click / not to-me). */
+static bool        autosel_qso_active = false;
+
+/* Number of times we've actually transmitted the current grid-exchange message
+ * (remote local GRID) in this AutoSel QSO.
+ */
+static uint8_t     autosel_grid_tx_count = 0;
+
+/* Pending "to-me" caller observed while TX is exhausted (priority reply). */
+static bool         pending_to_me_valid = false;
+static bool         pending_to_me_odd = false;
+static ftx_msg_meta_t pending_to_me_meta;
+
+/* Pending "to-me GRID" caller observed while AutoSel is trying to call a CQ
+ * and repeatedly sending our grid. Used to switch before repeats are exhausted.
+ */
+static bool          pending_grid_to_me_valid = false;
+static bool          pending_grid_to_me_odd = false;
+static ftx_msg_meta_t pending_grid_to_me_meta;
 
 static ftx_tx_msg_t tx_msg;
 
-static lv_obj_t *table;
+/* Helper that returns the LVGL table object owned by table_view; used by the
+ * fade animation and a few legacy spots. */
+#define table  (table_view_obj())
 
 static lv_timer_t *timer = NULL;
 static lv_anim_t   fade;
@@ -120,22 +164,36 @@ static bool        disable_buttons = false;
 static lv_obj_t *finder;
 static lv_obj_t *waterfall;
 static uint16_t  waterfall_nfft;
-static spgramcf  waterfall_sg;
-static float    *waterfall_psd;
-static uint8_t   waterfall_fps_ms = (1000 / 5);
-static uint64_t  waterfall_time;
+/* Waterfall marker: draw a red horizontal line at each new slot boundary. */
+static uint64_t ft8_waterfall_slot_start_seen = 0;
 
-static pthread_mutex_t audio_mutex = PTHREAD_MUTEX_INITIALIZER;
-static cbuffercf       audio_buf;
-static pthread_t       thread;
+/* Auto DNF: tuning parameters (file-loaded) + the module instance. */
+#include "ft8/params.h"
+#include "ft8/auto_dnf.h"
+#include "ft8/audio_worker.h"
 
-static firdecim_crcf  decim;
-static float complex *decim_buf;
+static ft8_tuning_t    ft8_tuning = {
+    .scan_start_sec = FT8_AUTO_DNF_SCAN_START_SEC_DEFAULT,
+    .scan_end_sec   = FT8_AUTO_DNF_SCAN_END_SEC_DEFAULT,
+    .clear_time_sec = FT8_AUTO_DNF_CLEAR_TIME_SEC_DEFAULT,
+    .min_delta_db   = FT8_AUTO_DNF_MIN_DELTA_DB_DEFAULT,
+};
+static auto_dnf_ctx_t *s_auto_dnf = NULL;
+static audio_worker_t *s_audio_worker = NULL;
+
+
+/* Cooperative sleep: wake up immediately when stop is requested instead of
+ * sitting out a full usleep() that pthread_cancel would otherwise have cut
+ * short at an unknown point. */
+
+
 
 static adif_log         ft8_log;
 static FTxQsoProcessor *qso_processor;
 
 static double cur_lat, cur_lon;
+/* Whether local QTH is valid and can be used for distance computations */
+static bool local_qth_valid = false;
 
 static int32_t filter_low, filter_high;
 
@@ -146,7 +204,35 @@ static void key_cb(lv_event_t * e);
 static void destruct_cb();
 static void audio_cb(unsigned int n, float complex *samples);
 static void rotary_cb(int32_t diff);
-static void * decode_thread(void *arg);
+
+/* Audio worker callbacks (run on worker thread, never touch LVGL directly). */
+static void on_message_cb(const char *text, int snr, float freq_hz, float time_sec,
+                          const slot_info_t *info, void *ctx);
+static void on_psd_cb(const float *psd, uint16_t nfft, float sec_since_slot_start,
+                      const slot_info_t *info, void *ctx);
+static void on_slot_end_cb(const slot_info_t *info, void *ctx);
+static void on_tick_cb(const slot_info_t *info, bool new_slot,
+                       float sec_since_slot_start, void *ctx);
+
+/* Auto DNF API lives in ft8/auto_dnf.h. */
+
+/* AutoSel: candidate list, blacklists and the selection mode all live in
+ * ft8/auto_sel.{cpp,h}. The current mode is the only piece of UI state we
+ * keep here. */
+#include "ft8/auto_sel.h"
+
+static auto_sel_mode_t auto_sel_mode = AUTO_SEL_OFF; /* default: off (user must opt-in) */
+
+static bool is_grid_exchange_msg(const char *msg) {
+    if (!msg || msg[0] == '\0') return false;
+    char t1[16] = {0};
+    char t2[16] = {0};
+    char t3[16] = {0};
+    if (sscanf(msg, "%15s %15s %15s", t1, t2, t3) != 3) return false;
+    /* Grid exchange is exactly 3 tokens and last token is a Maidenhead grid. */
+    return qth_grid_check(t3);
+}
+
 
 static const char * cq_all_label_getter();
 static const char * protocol_label_getter();
@@ -154,6 +240,9 @@ static const char * tx_cq_label_getter();
 static const char * tx_call_label_getter();
 static const char * hold_freq_label_getter();
 static const char * auto_label_getter();
+static const char * auto_dnf_label_getter();
+static const char * auto_sel_label_getter();
+static const char * xit_label_getter();
 
 static void show_cq_all_cb(struct button_item_t *btn);
 static void mode_ft4_ft8_cb(struct button_item_t *btn);
@@ -162,22 +251,39 @@ static void tx_call_en_dis_cb(struct button_item_t *btn);
 
 static void hold_tx_freq_cb(struct button_item_t *btn);
 static void mode_auto_cb(struct button_item_t *btn);
+static void auto_dnf_cb(struct button_item_t *btn);
 static void cq_modifier_cb(struct button_item_t *btn);
 static void time_sync(struct button_item_t *btn);
+static void mode_auto_sel_cb(struct button_item_t *btn);
+static void xit_cb(struct button_item_t *btn);
+
+static void free_msg_cb(struct button_item_t *btn);
 
 static void force_save_qso(struct button_item_t *btn);
 
-static void cell_press_cb(lv_event_t * e);
+static void on_table_press(const cell_data_t *cell_data);
+static void on_table_close(void);
+static void on_table_vol_change(int32_t delta);
 
 static void keyboard_open();
 static bool keyboard_cancel_cb();
 static bool keyboard_ok_cb();
 static void keyboard_close();
 
+static void free_msg_open();
+static void free_msg_close();
+static bool free_msg_cancel_cb();
+static bool free_msg_ok_cb();
+
 static void add_info(const char * fmt, ...);
 static void add_tx_text(const char * text);
+static void add_rx_text(int16_t snr, const char * text, slot_info_t *s_info, float freq_hz, float time_sec);
+static void tx_worker(float sec_since_slot_start);
 static void make_cq_msg(const char *callsign, const char *qth, const char *cq_mod, char *text);
 static bool get_time_slot(struct timespec now, float *time_since_start);
+
+static void schedule_cq_tx_if_needed();
+
 
 
 // button label is current state, press action and name - next state
@@ -185,32 +291,43 @@ static bool get_time_slot(struct timespec now, float *time_since_start);
 static buttons_page_t btn_page_1;
 static buttons_page_t btn_page_2;
 static buttons_page_t btn_page_3;
+static buttons_page_t btn_page_4;
 
-static button_item_t button_page_1 = { .type=BTN_TEXT, .label = "(Page: 1:3)", .press = button_next_page_cb, .next=&btn_page_2};
+static button_item_t button_page_1 = { .type=BTN_TEXT, .label = "(Page: 1:4)", .press = button_next_page_cb, .next=&btn_page_2};
 static button_item_t button_show_cq_all = { .type=BTN_TEXT_FN, .label_fn = cq_all_label_getter, .press = show_cq_all_cb, .subj=&cfg.ft8_show_all.val};
 static button_item_t button_mode_ft4_ft8 = { .type=BTN_TEXT_FN, .label_fn = protocol_label_getter, .press = mode_ft4_ft8_cb, .subj=&cfg.ft8_protocol.val };
 static button_item_t button_tx_cq_en_dis = { .type=BTN_TEXT_FN, .label_fn = tx_cq_label_getter, .press = tx_cq_en_dis_cb };
 static button_item_t button_tx_call_en_dis = { .type=BTN_TEXT_FN, .label_fn = tx_call_label_getter, .press = tx_call_en_dis_cb};
 
-static button_item_t button_page_2 = { .type=BTN_TEXT, .label = "(Page: 2:3)", .press = button_next_page_cb, .next=&btn_page_3};
+static button_item_t button_page_2 = { .type=BTN_TEXT, .label = "(Page: 2:4)", .press = button_next_page_cb, .next=&btn_page_3};
 static button_item_t button_hold_freq = { .type=BTN_TEXT_FN, .label_fn = hold_freq_label_getter, .press = hold_tx_freq_cb, .subj=&cfg.ft8_hold_freq.val };
 static button_item_t button_auto_en_dis = { .type=BTN_TEXT_FN, .label_fn = auto_label_getter, .press = mode_auto_cb, .subj=&cfg.ft8_auto.val };
 static button_item_t button_force_save = { .type=BTN_TEXT, .label = "Force QSO\nsave", .press = force_save_qso };
+static button_item_t button_free_msg = { .type=BTN_TEXT, .label = "Free\nMSG", .press = free_msg_cb };
 
-static button_item_t button_page_3 = { .type=BTN_TEXT, .label = "(Page: 3:3)", .press = button_next_page_cb, .next=&btn_page_1};
+static button_item_t button_page_3 = { .type=BTN_TEXT, .label = "(Page: 3:4)", .press = button_next_page_cb, .next=&btn_page_4};
 static button_item_t button_cq_mod = { .type=BTN_TEXT, .label = "CQ\nModifier", .press = cq_modifier_cb };
 static button_item_t button_time_sync = { .type=BTN_TEXT, .label = "Time\nSync", .press = time_sync };
+static button_item_t button_auto_sel = { .type=BTN_TEXT_FN, .label_fn = auto_sel_label_getter, .press = mode_auto_sel_cb };
+static button_item_t button_auto_dnf = { .type=BTN_TEXT_FN, .label_fn = auto_dnf_label_getter, .press = auto_dnf_cb, .subj=&cfg.ft8_auto_dnf.val };
+
+static button_item_t button_page_4 = { .type=BTN_TEXT, .label = "(Page: 4:4)", .press = button_next_page_cb, .next=&btn_page_1};
+static button_item_t button_xit = { .type=BTN_TEXT_FN, .label_fn = xit_label_getter, .press = xit_cb, .subj=&cfg.ft8_xit.val };
 
 static buttons_page_t btn_page_1 = {
-    {&button_page_1, &button_show_cq_all, &button_mode_ft4_ft8, &button_tx_cq_en_dis, &button_tx_call_en_dis}
+    {&button_page_1, &button_auto_sel, &button_mode_ft4_ft8, &button_tx_cq_en_dis, &button_tx_call_en_dis}
 };
 
 static buttons_page_t btn_page_2 = {
-    {&button_page_2, &button_hold_freq, &button_auto_en_dis, &button_force_save}
+    {&button_page_2, &button_hold_freq, &button_auto_en_dis, &button_force_save, &button_free_msg}
 };
 
 static buttons_page_t btn_page_3 = {
-    {&button_page_3, &button_cq_mod, &button_time_sync}
+    {&button_page_3, &button_cq_mod, &button_time_sync, &button_show_cq_all, &button_auto_dnf}
+};
+
+static buttons_page_t btn_page_4 = {
+    {&button_page_4, &button_xit, NULL, NULL, NULL}
 };
 
 static dialog_t dialog = {
@@ -242,7 +359,7 @@ static void save_qso(const char *remote_callsign, const char *remote_grid, const
     // Save QSO to sqlite log
     qso_log_record_save(qso);
 
-    if (strlen(remote_grid) >= 4) {
+    if (strlen(remote_grid) >= 4 && qth_grid_check(remote_grid) && local_qth_valid) {
         double lat, lon, dist;
         qth_str_to_pos(remote_grid, &lat, &lon);
         dist = qth_pos_dist(lat, lon, cur_lat, cur_lon);
@@ -252,256 +369,265 @@ static void save_qso(const char *remote_callsign, const char *remote_grid, const
     }
 
     lv_finder_clear_cursor(finder);
+    /* Already-worked status is recorded in the qso log via qso_log_record_save(). */
+    /* If we paused CQ to complete this QSO, restore it now */
+    if (cq_paused_for_qso) {
+        subject_set_int(cq_enabled, true);
+        cq_paused_for_qso = false;
+        schedule_cq_tx_if_needed();
+    }
+}
+
+static void schedule_cq_tx_if_needed() {
+    if (!cq_enabled || !subject_get_int(cq_enabled)) return;
+    if (!tx_enabled || !subject_get_int(tx_enabled)) return;
+    if (tx_msg.msg[0] != '\0') return;
+    if (ftx_qso_processor_has_current(qso_processor)) return;
+
+    if (strlen(params.callsign.x) == 0) return;
+
+    make_cq_msg(params.callsign.x, params.qth.x, params.ft8_cq_modifier.x, tx_msg.msg);
+    tx_msg.repeats = subject_get_int(cfg.ft8_max_repeats.val);
+    tx_msg.force_free_text = false;
+
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME, &now);
+    float time_since_slot_start;
+    tx_time_slot = !get_time_slot(now, &time_since_slot_start);
+    float max_delay = (subject_get_int(cfg.ft8_protocol.val) == FTX_PROTOCOL_FT8) ? MAX_TX_START_DELAY : MAX_TX_START_DELAY_FT4;
+    if (time_since_slot_start < max_delay) {
+        tx_time_slot = !tx_time_slot;
+    }
+
+    if (tx_msg.msg[2] == '_') {
+        msg_schedule_text_fmt("Next TX: CQ %s", tx_msg.msg + 3);
+    } else {
+        msg_schedule_text_fmt("Next TX: %s", tx_msg.msg);
+    }
 }
 
 static void worker_init() {
+    qso_processor = ftx_qso_processor_init(params.callsign.x, params.qth.x, save_qso,
+                                           subject_get_int(cfg.ft8_max_repeats.val));
 
-    /* ftx worker */
-    qso_processor = ftx_qso_processor_init(params.callsign.x, params.qth.x, save_qso, subject_get_int(cfg.ft8_max_repeats.val));
+    audio_worker_cb_t cb = {
+        .on_message  = on_message_cb,
+        .on_psd      = on_psd_cb,
+        .on_slot_end = on_slot_end_cb,
+        .on_tick     = on_tick_cb,
+        .ctx         = NULL,
+    };
 
-    ftx_worker_init(SAMPLE_RATE, subject_get_int(cfg.ft8_protocol.val));
-    int block_size = ftx_worker_get_block_size();
+    s_audio_worker = audio_worker_create(AUDIO_CAPTURE_RATE, DECIM,
+                                         (ftx_protocol_t)subject_get_int(cfg.ft8_protocol.val),
+                                         filter_low, filter_high, &cb);
+    if (!s_audio_worker) {
+        LV_LOG_ERROR("Failed to create audio_worker");
+        ftx_qso_processor_delete(qso_processor);
+        return;
+    }
+    waterfall_nfft = audio_worker_nfft(s_audio_worker);
 
-    decim_buf = (float complex *) malloc(block_size * sizeof(float complex));
-
-    /* Waterfall */
-    waterfall_nfft = (uint16_t)(WIDTH * SAMPLE_RATE / (filter_high - filter_low));
-
-    waterfall_sg = spgramcf_create(waterfall_nfft, LIQUID_WINDOW_HANN, waterfall_nfft, waterfall_nfft / 2);
-    waterfall_psd = (float *) malloc(waterfall_nfft * sizeof(float));
-    waterfall_time = get_time();
-
-    /* Worker */
-    pthread_create(&thread, NULL, decode_thread, NULL);
+    if (audio_worker_start(s_audio_worker) != 0) {
+        LV_LOG_ERROR("Failed to start audio_worker thread");
+        audio_worker_destroy(s_audio_worker);
+        s_audio_worker = NULL;
+        ftx_qso_processor_delete(qso_processor);
+        return;
+    }
 }
 
 static void worker_done() {
     state = RX_PROCESS;
 
-    pthread_cancel(thread);
-    pthread_join(thread, NULL);
+    if (s_audio_worker) {
+        audio_worker_stop(s_audio_worker);
+        audio_worker_destroy(s_audio_worker);
+        s_audio_worker = NULL;
+    }
+
     radio_set_modem(false);
-    pthread_mutex_unlock(&audio_mutex);
-    ftx_worker_free();
-    free(decim_buf);
-
-    spgramcf_destroy(waterfall_sg);
-    free(waterfall_psd);
-
     ftx_qso_processor_delete(qso_processor);
     lv_finder_clear_cursor(finder);
     tx_msg.msg[0] = '\0';
+    tx_msg.force_free_text = false;
+    autosel_recover_mode = false;
+    qso_tx_exhausted = false;
+    pending_to_me_valid = false;
+    qso_active_call[0] = '\0';
+
+    /* Free any accumulated unseen candidates if the dialog stops mid-slot. */
+    autosel_clear_unseen();
 }
 
-void static waterfall_process(float complex *frame, const size_t size) {
-    uint64_t now = get_time();
+/* ---------- audio_worker callbacks (run on worker thread) --------------- */
 
-    spgramcf_write(waterfall_sg, frame, size);
+typedef struct {
+    float          *psd_copy;
+    uint16_t        cnt;
+    struct timespec ts;
+    bool            add_marker;
+} wf_frame_t;
 
-    if (now - waterfall_time > waterfall_fps_ms) {
-        uint32_t low_bin = waterfall_nfft / 2 + waterfall_nfft * filter_low / SAMPLE_RATE;
-        uint32_t high_bin = waterfall_nfft / 2 + waterfall_nfft * filter_high / SAMPLE_RATE;
+static void wf_push_cb(void *arg) {
+    wf_frame_t *f = (wf_frame_t *)arg;
+    if (!f || !waterfall) return;
+    if (f->add_marker) {
+        lv_waterfall_add_marker_line(waterfall, lv_color_hex(0xFF0000));
+    }
+    lv_waterfall_add_data_with_ts(waterfall, f->psd_copy, f->cnt, f->ts);
+    free(f->psd_copy);
+}
 
-        high_bin = LV_MIN(high_bin, waterfall_nfft);
+static void on_psd_cb(const float *psd, uint16_t nfft, float sec_since_slot_start,
+                      const slot_info_t *info, void *ctx) {
+    (void)ctx;
+    (void)sec_since_slot_start;
+    uint32_t low_bin  = (uint32_t)(nfft / 2 + (int32_t)nfft * filter_low  / SAMPLE_RATE);
+    uint32_t high_bin = (uint32_t)(nfft / 2 + (int32_t)nfft * filter_high / SAMPLE_RATE);
+    if (high_bin > nfft) high_bin = nfft;
+    if (high_bin <= low_bin) return;
+    uint16_t cnt = (uint16_t)(high_bin - low_bin);
 
-        spgramcf_get_psd(waterfall_sg, waterfall_psd);
-        // Normalize FFT
-        liquid_vectorf_addscalar(
-            &waterfall_psd[low_bin],
-            high_bin - low_bin,
-            -10.f * log10f(sqrtf(waterfall_nfft)),
-            &waterfall_psd[low_bin]);
+    /* Copy PSD band for waterfall (freed by wf_push_cb on UI thread). */
+    wf_frame_t push = { .add_marker = false };
+    push.cnt = cnt;
+    push.psd_copy = (float *)malloc(cnt * sizeof(float));
+    if (push.psd_copy) {
+        memcpy(push.psd_copy, &psd[low_bin], cnt * sizeof(float));
+    }
+    push.ts.tv_sec  = info->slot_start;
+    push.ts.tv_nsec = 0;
 
-        lv_waterfall_add_data(waterfall, &waterfall_psd[low_bin], high_bin - low_bin);
+    /* Slot boundary marker. */
+    int proto = subject_get_int(cfg.ft8_protocol.val);
+    uint64_t slot_ns = (proto == FTX_PROTOCOL_FT4) ? 7500000000ULL : 15000000000ULL;
+    uint64_t slot_id = (uint64_t)((uint64_t)info->slot_start * 1000000000ULL) / slot_ns;
+    if (slot_id != ft8_waterfall_slot_start_seen) {
+        ft8_waterfall_slot_start_seen = slot_id;
+        push.add_marker = true;
+    }
 
-        waterfall_time = now;
-        spgramcf_reset(waterfall_sg);
+    /* Auto DNF. */
+    if (s_auto_dnf && state == RX_PROCESS) {
+        struct timespec frame_ts;
+        frame_ts.tv_sec  = (time_t)info->slot_start;
+        frame_ts.tv_nsec = 0;
+        float dummy_sec;
+        bool have_tx_msg    = tx_msg.msg[0] != '\0';
+        bool is_our_tx_slot = (subject_get_int(tx_enabled) && have_tx_msg &&
+                               (tx_time_slot == get_time_slot(frame_ts, &dummy_sec)));
+        auto_dnf_on_psd(s_auto_dnf, psd, nfft, SAMPLE_RATE,
+                        filter_low, filter_high, frame_ts, is_our_tx_slot);
+    }
+
+    scheduler_put(wf_push_cb, &push, sizeof(push));
+}
+
+static void on_message_cb(const char *text, int snr, float freq_hz, float time_sec,
+                          const slot_info_t *info, void *ctx) {
+    (void)ctx;
+    add_rx_text((int16_t)snr, text, (slot_info_t *)info, freq_hz, time_sec);
+}
+
+static void on_slot_end_cb(const slot_info_t *info, void *ctx) {
+    (void)ctx;
+    state = RX_PROCESS;
+    struct tm tm_buf;
+    time_t slot_start_t = (time_t)info->slot_start;
+    if (localtime_r(&slot_start_t, &tm_buf) != NULL) {
+        add_info("RX %s %02i:%02i:%02i", cfg_digital_label_get(),
+                 tm_buf.tm_hour, tm_buf.tm_min, tm_buf.tm_sec);
     }
 }
 
-static void scroll_table_down_cb(lv_timer_t *t) {
-    static int32_t c = LV_KEY_DOWN;
-    lv_event_send(table, LV_EVENT_KEY, &c);
-    if (t){
-        lv_timer_del(t);
-    }
-}
+static void on_tick_cb(const slot_info_t *info, bool new_slot,
+                       float sec_since_slot_start, void *ctx) {
+    (void)ctx;
+    bool have_tx_msg = tx_msg.msg[0] != '\0';
 
-static void truncate_table() {
-    lv_coord_t     removed_rows_height = 0;
-    uint16_t       table_rows = lv_table_get_row_cnt(table);
-    if (table_rows > MAX_TABLE_MSG) {
-        LV_LOG_USER("Start");
+    float tx_max_delay = (subject_get_int(cfg.ft8_protocol.val) == FTX_PROTOCOL_FT8)
+                         ? MAX_TX_START_DELAY : MAX_TX_START_DELAY_FT4;
+    if ((sec_since_slot_start < tx_max_delay) && have_tx_msg) {
+        if ((tx_time_slot == info->odd) && subject_get_int(tx_enabled)) {
+            if (s_auto_dnf) {
+                auto_dnf_clear_for_tx(s_auto_dnf);
+            }
+            state = TX_PROCESS;
 
-        lv_table_t *table_obj = (lv_table_t*) table;
+            bool sent_grid = is_grid_exchange_msg(tx_msg.msg);
+            ft8_log_tx((time_t)info->slot_start,
+                       (uint64_t)subject_get_int(cfg_cur.fg_freq),
+                       params.ft8_tx_freq.x, tx_msg.msg);
+            add_tx_text(tx_msg.msg);
+            tx_worker(sec_since_slot_start);
 
-        for (size_t i = 0; i < CLEAN_N_ROWS; i++) {
-            removed_rows_height += table_obj->row_h[i];
-        }
-
-        if (table_obj->row_act > CLEAN_N_ROWS) {
-            table_obj->row_act -= CLEAN_N_ROWS;
-        } else {
-            table_obj->row_act = 0;
-        }
-
-        for (uint16_t i = CLEAN_N_ROWS; i < table_rows; i++) {
-            cell_data_t *cell_data_copy = malloc(sizeof(cell_data_t));
-            lv_table_set_cell_value(table, i-CLEAN_N_ROWS, 0, lv_table_get_cell_value(table, i, 0));
-            *cell_data_copy = *(cell_data_t *) lv_table_get_cell_user_data(table, i, 0);
-            lv_table_set_cell_user_data(table, i-CLEAN_N_ROWS, 0, cell_data_copy);
-        }
-        table_rows -= CLEAN_N_ROWS;
-
-        lv_table_set_row_cnt(table, table_rows);
-        lv_obj_scroll_by_bounded(table, 0, removed_rows_height, LV_ANIM_OFF);
-    }
-}
-
-static void add_msg_cb(void *data) {
-    truncate_table();
-    uint16_t    row = 0;
-    uint16_t    col = 0;
-    bool        scroll;
-
-    lv_table_get_selected_cell(table, &row, &col);
-    uint16_t table_rows = lv_table_get_row_cnt(table);
-    if ((table_rows == 1) && strcmp(lv_table_get_cell_value(table, 0, 0), WAIT_SYNC_TEXT) == 0) {
-        table_rows--;
-    }
-    scroll = table_rows == (row + 1);
-
-    // Copy data, because original event data will be deleted
-    cell_data_t *cell_data = (cell_data_t*)data;
-    cell_data_t *cell_data_copy = malloc(sizeof(cell_data_t));
-    *cell_data_copy = *cell_data;
-
-    lv_table_set_cell_value(table, table_rows, 0, cell_data_copy->text);
-    lv_table_set_cell_user_data(table, table_rows, 0, cell_data_copy);
-
-    if (scroll) {
-        uint32_t delay = 0;
-        if (cell_data->cell_type == CELL_RX_INFO) {
-            lv_timer_create(scroll_table_down_cb, 2000, NULL);
-        } else {
-            scroll_table_down_cb(NULL);
-        }
-    }
-}
-
-static void table_draw_part_begin_cb(lv_event_t * e) {
-    lv_obj_t                *obj = lv_event_get_target(e);
-    lv_obj_draw_part_dsc_t  *dsc = lv_event_get_draw_part_dsc(e);
-
-    if (dsc->part == LV_PART_ITEMS) {
-        uint32_t    row = dsc->id / lv_table_get_col_cnt(obj);
-        uint32_t    col = dsc->id - row * lv_table_get_col_cnt(obj);
-        cell_data_t *cell_data = lv_table_get_cell_user_data(obj, row, col);
-
-        dsc->rect_dsc->bg_opa = LV_OPA_50;
-
-        if (cell_data == NULL) {
-            dsc->label_dsc->align = LV_TEXT_ALIGN_CENTER;
-            dsc->rect_dsc->bg_color = lv_color_hex(0x303030);
-        } else {
-            switch (cell_data->cell_type) {
-                case CELL_RX_INFO:
-                    dsc->label_dsc->align = LV_TEXT_ALIGN_CENTER;
-                    dsc->rect_dsc->bg_color = lv_color_hex(0x303030);
-                    break;
-
-                case CELL_RX_CQ:
-                    switch (cell_data->worked_type) {
-                        case SEARCH_WORKED_NO:
-                            // green
-                            dsc->rect_dsc->bg_color = lv_color_hex(0x00DD00);
-                            break;
-                        case SEARCH_WORKED_YES:
-                            // dark green
-                            dsc->label_dsc->opa = LV_OPA_90;
-                            dsc->rect_dsc->bg_color = lv_color_hex(0x2e5a00);
-                            break;
-                        case SEARCH_WORKED_SAME_MODE:
-                            // darker green
-                            dsc->label_dsc->decor = LV_TEXT_DECOR_STRIKETHROUGH;
-                            dsc->label_dsc->opa = LV_OPA_80;
-                            dsc->rect_dsc->bg_color = lv_color_hex(0x224400);
-                            break;
+            if (sent_grid && autosel_qso_active && (autosel_grid_tx_count < 255)) {
+                autosel_grid_tx_count++;
+            }
+            if (tx_msg.repeats > 0) {
+                tx_msg.repeats--;
+            }
+            if (tx_msg.repeats == 0) {
+                bool was_cq = (strncmp(tx_msg.msg, "CQ", 2) == 0);
+                if (!was_cq && ftx_qso_processor_has_current(qso_processor)) {
+                    qso_tx_exhausted = true;
+                    if (is_grid_exchange_msg(tx_msg.msg)) {
+                        autosel_blacklist_add(qso_active_call);
                     }
-                    break;
-
-                case CELL_RX_TO_ME:
-                    dsc->rect_dsc->bg_color = lv_color_hex(0xFF0000);
-                    break;
-
-                case CELL_TX_MSG:
-                    dsc->rect_dsc->bg_color = lv_color_hex(0x0000FF);
-                    break;
-                default:
-                    dsc->rect_dsc->bg_color = lv_color_black();
-                    break;
+                    if ((auto_sel_mode != AUTO_SEL_OFF) && !cq_paused_for_qso) {
+                        autosel_recover_mode = true;
+                    }
+                }
+                if (was_cq) {
+                    subject_set_int(cq_enabled, false);
+                }
+                tx_msg.msg[0] = '\0';
+                tx_msg.force_free_text = false;
+                if (cq_paused_for_qso && !ftx_qso_processor_has_current(qso_processor)) {
+                    subject_set_int(cq_enabled, true);
+                    cq_paused_for_qso = false;
+                    schedule_cq_tx_if_needed();
+                }
+                if (!was_cq && !cq_paused_for_qso && !ftx_qso_processor_has_current(qso_processor) &&
+                    cq_enabled && subject_get_int(cq_enabled) && (tx_msg.msg[0] == '\0')) {
+                    schedule_cq_tx_if_needed();
+                }
             }
-        }
-
-        uint16_t    selected_row, selected_col;
-        lv_table_get_selected_cell(obj, &selected_row, &selected_col);
-
-        if (selected_row == row) {
-            dsc->rect_dsc->bg_color = lv_color_lighten(dsc->rect_dsc->bg_color, 20);
         }
     }
 }
 
-static void table_draw_part_end_cb(lv_event_t * e) {
-    lv_obj_t                *obj = lv_event_get_target(e);
-    lv_obj_draw_part_dsc_t  *dsc = lv_event_get_draw_part_dsc(e);
+/* clip_i32 / overlay_update / restore / scheduler trampolines all live in
+ * ft8/auto_dnf.c. Anything still poking at them goes through the module
+ * API: auto_dnf_on_psd / auto_dnf_clear_for_tx / auto_dnf_restore_entry. */
 
-    if (dsc->part == LV_PART_ITEMS) {
-        uint32_t    row = dsc->id / lv_table_get_col_cnt(obj);
-        uint32_t    col = dsc->id - row * lv_table_get_col_cnt(obj);
-        cell_data_t *cell_data = lv_table_get_cell_user_data(obj, row, col);
+/* truncate_table / add_msg_cb / draw_part_*_cb live in ft8/table_view.c.
+ * Worker thread feeds rows via scheduler_put(table_view_add_msg_cb, ...). */
 
-        if (cell_data == NULL) {
-            return;
-        }
-
-        if ((cell_data->cell_type == CELL_RX_MSG) ||
-            (cell_data->cell_type == CELL_RX_CQ) ||
-            (cell_data->cell_type == CELL_RX_TO_ME)
-        ) {
-            char                buf[64];
-            const lv_coord_t    cell_top = lv_obj_get_style_pad_top(obj, LV_PART_ITEMS);
-            const lv_coord_t    cell_bottom = lv_obj_get_style_pad_bottom(obj, LV_PART_ITEMS);
-            lv_area_t           area;
-
-            dsc->label_dsc->align = LV_TEXT_ALIGN_RIGHT;
-
-            area.y1 = dsc->draw_area->y1 + cell_top;
-            area.y2 = dsc->draw_area->y2 - cell_bottom;
-
-            area.x2 = dsc->draw_area->x2 - 15;
-            area.x1 = area.x2 - 120;
-
-            snprintf(buf, sizeof(buf), "%i dB", cell_data->meta.local_snr);
-            lv_draw_label(dsc->draw_ctx, dsc->label_dsc, &area, buf, NULL);
-
-            if (cell_data->dist > 0) {
-                area.x2 = area.x1 - 10;
-                area.x1 = area.x2 - 200;
-
-                snprintf(buf, sizeof(buf), "%i km", cell_data->dist);
-                lv_draw_label(dsc->draw_ctx, dsc->label_dsc, &area, buf, NULL);
-            }
-        }
-    }
+static void deferred_destruct_cb(void *arg) {
+    (void)arg;
+    dialog_destruct();
 }
 
 static void key_cb(lv_event_t * e) {
-    uint32_t key = *((uint32_t *) lv_event_get_param(e));
+    uint32_t *key_ptr = (uint32_t *) lv_event_get_param(e);
+    uint32_t key = *key_ptr;
+
+    /* In FT8 list only: swap LEFT/RIGHT so remote + (top) = scroll up, - (bottom) = scroll down */
+    if (key == LV_KEY_LEFT) {
+        *key_ptr = LV_KEY_RIGHT;
+        key = LV_KEY_RIGHT;
+    } else if (key == LV_KEY_RIGHT) {
+        *key_ptr = LV_KEY_LEFT;
+        key = LV_KEY_LEFT;
+    }
 
     switch (key) {
         case LV_KEY_ESC:
-            dialog_destruct(&dialog);
+            /* Defer so we do not delete the dialog from within its own key handler
+             * (avoids crash and ensures destruct_cb / DNF restore run after event). */
+            lv_async_call(deferred_destruct_cb, NULL);
             break;
 
         case KEY_VOL_LEFT_EDIT:
@@ -517,12 +643,25 @@ static void key_cb(lv_event_t * e) {
 }
 
 static void destruct_cb() {
-    // TODO: check free mem
-    keyboard_close();
+
+    /* Stop active work immediately to avoid race conditions with observers/table. */
     worker_done();
 
-    firdecim_crcf_destroy(decim);
-    free(audio_buf);
+    /* Restore DNF first so it is applied even if we crash during teardown
+     * (e.g. when closing via VOL/APP and object is torn down from event handler).
+     * auto_dnf_destroy() also restores entry as a safety net. */
+    if (s_auto_dnf) {
+        auto_dnf_restore_entry(s_auto_dnf);
+    }
+
+
+    /* table_view_destroy below cleans up the LVGL table; pool is static
+     * and needs no per-cell free. */
+    keyboard_close();
+
+    /* Free any pending AutoSel candidates and clear blacklist state. */
+    autosel_clear_unseen();
+    autosel_blacklist_clear_all();
 
     mem_load(MEM_BACKUP_ID);
 
@@ -533,6 +672,21 @@ static void destruct_cb() {
 
     radio_set_pwr(subject_get_float(cfg.pwr.val));
     adif_log_close(ft8_log);
+    ft8_log_close();
+
+    /* Tear down the LVGL table object. The cell pool is static so there
+     * is nothing else to free. */
+    table_view_destroy();
+
+    dsp_set_waterfall_enabled(true);
+    dsp_set_spectrum_enabled(true);
+
+    /* Auto-DNF context owns observers + LVGL overlay objects (already torn
+     * down with the dialog). Destroy releases the max-pool buffer. */
+    if (s_auto_dnf) {
+        auto_dnf_destroy(s_auto_dnf);
+        s_auto_dnf = NULL;
+    }
 }
 
 static void load_band(int8_t dir) {
@@ -556,16 +710,11 @@ static void load_band(int8_t dir) {
 
 /// @brief Clean waterfall and table
 static void clean_screen() {
-    lv_table_set_row_cnt(table, 0);
-    lv_table_set_row_cnt(table, 1);
-    lv_table_set_cell_value(table, 0, 0, WAIT_SYNC_TEXT);
-
+    table_view_reset();
     lv_waterfall_clear_data(waterfall);
 
-    int32_t *c = malloc(sizeof(int32_t));
-    *c = LV_KEY_UP;
-
-    lv_event_send(table, LV_EVENT_KEY, c);
+    int32_t c = LV_KEY_UP;
+    lv_event_send(table, LV_EVENT_KEY, &c);
 }
 
 static void band_cb(lv_event_t * e) {
@@ -598,6 +747,29 @@ static void fade_ready(lv_anim_t * a) {
     fade_run = false;
 }
 
+static void set_freq(uint32_t freq);
+
+static void set_freq_ui_cb(void *param) {
+    uint32_t freq;
+    memcpy(&freq, param, sizeof(freq));
+    lv_finder_set_value(finder, freq);
+    lv_obj_invalidate(finder);
+}
+
+static void set_freq_ui_async(uint32_t freq) {
+    scheduler_put(set_freq_ui_cb, &freq, sizeof(freq));
+}
+
+static void finder_set_cursor_cb(void *param) {
+    uint32_t freq_hz;
+    memcpy(&freq_hz, param, sizeof(freq_hz));
+    lv_finder_set_cursor(finder, freq_hz);
+}
+
+static void finder_set_cursor_async(uint32_t freq_hz) {
+    scheduler_put(finder_set_cursor_cb, &freq_hz, sizeof(freq_hz));
+}
+
 static void set_freq(uint32_t freq) {
     if (freq > filter_high) {
         freq = filter_high;
@@ -609,8 +781,10 @@ static void set_freq(uint32_t freq) {
 
     params_uint16_set(&params.ft8_tx_freq, freq);
 
-    lv_finder_set_value(finder, freq);
-    lv_obj_invalidate(finder);
+    /* UI updates must run on the LVGL/UI thread; the param update above is
+     * time-critical (it affects actual TX frequency selection).
+     */
+    set_freq_ui_async(freq);
 }
 
 static void rotary_cb(int32_t diff) {
@@ -641,6 +815,34 @@ static void rotary_cb(int32_t diff) {
 static void construct_cb(lv_obj_t *parent) {
     dialog.obj = dialog_init(parent);
 
+    dsp_set_waterfall_enabled(false);
+    dsp_set_spectrum_enabled(false);
+
+    /* Load tuning parameters before creating the auto_dnf module so it gets
+     * the user's current values. */
+    ft8_params_load(&ft8_tuning);
+
+    /* Auto DNF: create module instance (registers band/att/pre observers,
+     * snapshots the current DNF state for restore-on-exit). */
+    s_auto_dnf = auto_dnf_create(&ft8_tuning);
+    auto_dnf_snapshot_entry(s_auto_dnf);
+
+    /* Ensure no stale AutoSel state leaks across dialog reopen. */
+    autosel_clear_unseen();
+    autosel_blacklist_clear_all();
+    autosel_user_blacklist_load();
+    autosel_recover_mode = false;
+    qso_tx_exhausted = false;
+    pending_to_me_valid = false;
+    qso_active_call[0] = '\0';
+    cq_paused_for_qso = false;
+    tx_msg.msg[0] = '\0';
+    tx_msg.repeats = 0;
+    tx_msg.force_free_text = false;
+    autosel_qso_active = false;
+    autosel_grid_tx_count = 0;
+    pending_grid_to_me_valid = false;
+
     lv_obj_add_event_cb(dialog.obj, band_cb, EVENT_BAND_UP, NULL);
     lv_obj_add_event_cb(dialog.obj, band_cb, EVENT_BAND_DOWN, NULL);
 
@@ -657,10 +859,6 @@ static void construct_cb(lv_obj_t *parent) {
 
     buttons_load_page(&btn_page_1);
 
-    decim = firdecim_crcf_create_kaiser(DECIM, 8, 40.0f);
-    firdecim_crcf_set_scale(decim, 1.0f / DECIM);
-    audio_buf = cbuffercf_create(AUDIO_CAPTURE_RATE * 3);
-
     /* Waterfall */
 
     waterfall = lv_waterfall_create(dialog.obj);
@@ -673,6 +871,14 @@ static void construct_cb(lv_obj_t *parent) {
     lv_waterfall_set_min(waterfall, -60);
 
     lv_obj_set_pos(waterfall, 13, 13);
+
+    /* Auto DNF overlay (blue peak lines + delta_db label, drawn over the
+     * waterfall). filter_low/high are populated below; we patch them in once
+     * load_band() has run. For now use the cached values. */
+    auto_dnf_build_overlay(s_auto_dnf, dialog.obj,
+                           13, 13, 325, WIDTH,
+                           subject_get_int(cfg_cur.filter.low),
+                           subject_get_int(cfg_cur.filter.high));
 
     /* Freq finder */
 
@@ -695,37 +901,14 @@ static void construct_cb(lv_obj_t *parent) {
     lv_obj_set_style_border_color(finder, lv_color_white(), LV_PART_INDICATOR);
     lv_obj_set_style_border_opa(finder, LV_OPA_50, LV_PART_INDICATOR);
 
-    /* Table */
-
-    table = lv_table_create(dialog.obj);
-
-    lv_obj_remove_style(table, NULL, LV_STATE_ANY | LV_PART_MAIN);
-    lv_obj_add_event_cb(table, cell_press_cb, LV_EVENT_PRESSED, NULL);
-    lv_obj_add_event_cb(table, key_cb, LV_EVENT_KEY, NULL);
-    lv_obj_add_event_cb(table, table_draw_part_begin_cb, LV_EVENT_DRAW_PART_BEGIN, NULL);
-    lv_obj_add_event_cb(table, table_draw_part_end_cb, LV_EVENT_DRAW_PART_END, NULL);
-
-    lv_obj_set_size(table, WIDTH, 325 - 55);
-    lv_obj_set_pos(table, 13, 13 + 55);
-
-    lv_table_set_col_cnt(table, 1);
-    lv_table_set_col_width(table, 0, WIDTH - 2);
-
-    lv_obj_set_style_border_width(table, 0, LV_PART_ITEMS);
-
-    lv_obj_set_style_bg_opa(table, 192, LV_PART_MAIN);
-    lv_obj_set_style_bg_color(table, lv_color_black(), LV_PART_MAIN);
-    lv_obj_set_style_border_width(table, 1, LV_PART_MAIN);
-    lv_obj_set_style_border_color(table, lv_color_white(), LV_PART_MAIN);
-    lv_obj_set_style_border_opa(table, 128, LV_PART_MAIN);
-
-    lv_obj_set_style_text_color(table, lv_color_hex(0xC0C0C0), LV_PART_ITEMS);
-    lv_obj_set_style_pad_top(table, 3, LV_PART_ITEMS);
-    lv_obj_set_style_pad_bottom(table, 3, LV_PART_ITEMS);
-    lv_obj_set_style_pad_left(table, 5, LV_PART_ITEMS);
-    lv_obj_set_style_pad_right(table, 0, LV_PART_ITEMS);
-
-    lv_table_set_cell_value(table, 0, 0, "Wait sync");
+    /* Table view (cell ring pool, draw cbs, ESC/VOL key handling). */
+    table_view_build(dialog.obj, 13, 13 + 55, WIDTH, 325 - 55);
+    table_view_set_press_cb(on_table_press);
+    table_view_actions_t tv_actions = {
+        .on_close      = on_table_close,
+        .on_vol_change = on_table_vol_change,
+    };
+    table_view_set_actions(&tv_actions);
 
     /* Fade */
 
@@ -748,7 +931,14 @@ static void construct_cb(lv_obj_t *parent) {
 
     lv_finder_set_range(finder, filter_low, filter_high);
 
-    qth_str_to_pos(params.qth.x, &cur_lat, &cur_lon);
+    if (params.qth.x[0] != '\0' && qth_grid_check(params.qth.x)) {
+        qth_str_to_pos(params.qth.x, &cur_lat, &cur_lon);
+        local_qth_valid = true;
+    } else {
+        cur_lat = 0.0;
+        cur_lon = 0.0;
+        local_qth_valid = false;
+    }
 
     main_screen_lock_ab(true);
     main_screen_lock_mode(true);
@@ -767,12 +957,8 @@ static void construct_cb(lv_obj_t *parent) {
 
     // setup gain offset
     float target_pwr = LV_MIN(subject_get_float(cfg.pwr.val), MAX_PWR);
-    if (x6100_control_get_base_ver().rev >= 3) {
-        // patched firmware has a true power control
-        base_gain_offset = -9.4f;
-    } else {
-        base_gain_offset = -16.4f + log10f(target_pwr) * 10.0f;
-    }
+    // patched firmware has a true power control
+    base_gain_offset = -16.4f + log10f(target_pwr) * 10.0f;
 }
 
 /* Buttons */
@@ -813,6 +999,60 @@ const char *auto_label_getter() {
     return buf;
 }
 
+const char *auto_dnf_label_getter() {
+    static char buf[32];
+    sprintf(buf, "Auto DNF:\n%s", subject_get_int(cfg.ft8_auto_dnf.val) ? "On" : "Off");
+    return buf;
+}
+
+const char *xit_label_getter() {
+    static char buf[32];
+    sprintf(buf, "XIT:\n%s", subject_get_int(cfg.ft8_xit.val) ? "On" : "Off");
+    return buf;
+}
+
+const char *auto_sel_label_getter() {
+    static char buf[32];
+    const char *s;
+    switch (auto_sel_mode) {
+        case AUTO_SEL_OFF: s = "Off"; break;
+        case AUTO_SEL_FIRST: s = "First"; break;
+        case AUTO_SEL_FARTHEST: s = "Farthest"; break;
+        case AUTO_SEL_HIGHEST_SNR: s = "Best SNR"; break;
+        case AUTO_SEL_NEW_GRID: s = "New Grid"; break;
+        default: s = "?"; break;
+    }
+    sprintf(buf, "AutoSel:\n%s", s);
+    return buf;
+}
+
+void mode_auto_sel_cb(struct button_item_t *btn) {
+    if (disable_buttons) return;
+    auto_sel_mode = (auto_sel_mode + 1) % 5;
+    const char *s;
+    switch (auto_sel_mode) {
+        case AUTO_SEL_OFF: s = "Off"; break;
+        case AUTO_SEL_FIRST: s = "First"; break;
+        case AUTO_SEL_FARTHEST: s = "Farthest"; break;
+        case AUTO_SEL_HIGHEST_SNR: s = "Best SNR"; break;
+        case AUTO_SEL_NEW_GRID: s = "New Grid"; break;
+        default: s = "?"; break;
+    }
+    msg_schedule_text_fmt("Auto select: %s", s);
+    /* If user turned AutoSel Off, clear any accumulated unseen candidates. */
+    if (auto_sel_mode == AUTO_SEL_OFF) {
+        autosel_clear_unseen();
+        autosel_blacklist_clear_all();
+        autosel_qso_active = false;
+        autosel_grid_tx_count = 0;
+        pending_grid_to_me_valid = false;
+        autosel_recover_mode = false;
+    }
+
+    /* auto_sel_mode is not a Subject-backed value, so force a button label refresh. */
+    buttons_refresh(btn);
+}
+
 static void show_cq_all_cb(struct button_item_t *btn) {
     if (disable_buttons) return;
     subject_set_int(cfg.ft8_show_all.val, !subject_get_int(cfg.ft8_show_all.val));
@@ -843,6 +1083,20 @@ static void mode_auto_cb(struct button_item_t *btn) {
     ftx_qso_processor_set_auto(qso_processor, new_val);
 }
 
+static void auto_dnf_cb(struct button_item_t *btn) {
+    if (disable_buttons) return;
+    bool new_val = !subject_get_int(cfg.ft8_auto_dnf.val);
+    subject_set_int(cfg.ft8_auto_dnf.val, new_val);
+    if (!new_val && s_auto_dnf) {
+        auto_dnf_restore_entry(s_auto_dnf);
+    }
+}
+
+static void xit_cb(struct button_item_t *btn) {
+    if (disable_buttons) return;
+    subject_set_int(cfg.ft8_xit.val, !subject_get_int(cfg.ft8_xit.val));
+}
+
 static void hold_tx_freq_cb(struct button_item_t *btn) {
     if (disable_buttons) return;
     subject_set_int(cfg.ft8_hold_freq.val, !subject_get_int(cfg.ft8_hold_freq.val));
@@ -860,12 +1114,14 @@ static void tx_cq_en_dis_cb(struct button_item_t *btn) {
         subject_set_int(tx_enabled, true);
 
         make_cq_msg(params.callsign.x, params.qth.x, params.ft8_cq_modifier.x, tx_msg.msg);
+        tx_msg.force_free_text = false;
 
         struct timespec now;
         clock_gettime(CLOCK_REALTIME, &now);
         float time_since_slot_start;
         tx_time_slot = !get_time_slot(now, &time_since_slot_start);
-        if (time_since_slot_start < MAX_TX_START_DELAY) {
+        float max_delay = (subject_get_int(cfg.ft8_protocol.val) == FTX_PROTOCOL_FT8) ? MAX_TX_START_DELAY : MAX_TX_START_DELAY_FT4;
+        if (time_since_slot_start < max_delay) {
             tx_time_slot = !tx_time_slot;
         }
 
@@ -877,12 +1133,30 @@ static void tx_cq_en_dis_cb(struct button_item_t *btn) {
         tx_msg.repeats = subject_get_int(cfg.ft8_max_repeats.val);
         ftx_qso_processor_reset(qso_processor);
         lv_finder_clear_cursor(finder);
+        autosel_recover_mode = false;
+        qso_tx_exhausted = false;
+        pending_to_me_valid = false;
+        qso_active_call[0] = '\0';
+        autosel_qso_active = false;
+        autosel_grid_tx_count = 0;
+        pending_grid_to_me_valid = false;
     } else {
         if (state == TX_PROCESS) {
             state = RX_PROCESS;
         }
         subject_set_int(cq_enabled, false);
+        /* If user manually disables CQ, clear the paused-for-qso flag
+         * so automatic restore does not re-enable CQ against user intent. */
+        cq_paused_for_qso = false;
         tx_msg.msg[0] = '\0';
+        tx_msg.force_free_text = false;
+        autosel_recover_mode = false;
+        qso_tx_exhausted = false;
+        pending_to_me_valid = false;
+        qso_active_call[0] = '\0';
+        autosel_qso_active = false;
+        autosel_grid_tx_count = 0;
+        pending_grid_to_me_valid = false;
     }
 }
 
@@ -906,6 +1180,9 @@ static void tx_call_en_dis_cb(struct button_item_t *btn) {
 
 static void tx_call_off() {
     state = RX_PROCESS;
+    /* If a TX is in progress, signal the play loop to break out at the next
+     * 2k-sample boundary instead of hanging until the slot ends. */
+    tx_worker_request_abort();
     subject_set_int(tx_enabled, false);
 }
 
@@ -950,39 +1227,60 @@ static void force_save_qso(struct button_item_t *btn) {
     }
 }
 
-static void cell_press_cb(lv_event_t * e) {
+/* table_view press handler: replicates the legacy cell_press_cb business
+ * logic. Invoked from table_view's cell-pressed event after it has
+ * resolved the row's pool handle to a cell_data_t. */
+static void on_table_press(const cell_data_t *cell_data) {
     if (state == TX_PROCESS) {
         tx_call_off();
-    } else {
-        uint16_t     row;
-        uint16_t     col;
-
-        lv_table_get_selected_cell(table, &row, &col);
-
-        cell_data_t  *cell_data = lv_table_get_cell_user_data(table, row, col);
-
-        if ((cell_data == NULL) ||
-            (cell_data->cell_type == CELL_TX_MSG) ||
-            (cell_data->cell_type == CELL_RX_INFO)
-        ) {
-            msg_schedule_text_fmt("What should I do about it?");
-        } else {
-            ftx_qso_processor_start_qso(qso_processor, &cell_data->meta, &tx_msg);
-            if (strlen(tx_msg.msg) > 0) {
-                lv_finder_set_cursor(finder, cell_data->meta.freq_hz);
-                if (!subject_get_int(cfg.ft8_hold_freq.val)) {
-                    set_freq(cell_data->meta.freq_hz);
-                }
-                tx_time_slot = !cell_data->odd;
-                subject_set_int(tx_enabled, true);
-                add_info("Start QSO with %s", cell_data->meta.call_de);
-                msg_schedule_text_fmt("Next TX: %s", tx_msg.msg);
-            } else {
-                msg_schedule_text_fmt("Invalid message");
-                tx_call_off();
-            }
-        }
+        return;
     }
+
+    if ((cell_data == NULL) ||
+        (cell_data->cell_type == CELL_TX_MSG) ||
+        (cell_data->cell_type == CELL_RX_INFO)
+    ) {
+        msg_schedule_text_fmt("What should I do about it?");
+        return;
+    }
+
+    char prev_msg[sizeof(tx_msg.msg)];
+    memcpy(prev_msg, tx_msg.msg, sizeof(prev_msg));
+    ftx_qso_processor_start_qso(qso_processor, (ftx_msg_meta_t *)&cell_data->meta, &tx_msg);
+    if (strcmp(prev_msg, tx_msg.msg) != 0) {
+        tx_msg.force_free_text = false;
+    }
+    /* Log QSO entry for debugging even if TX is later aborted/invalid. */
+    ft8_log_qso(ft8_get_current_slot_start(), cell_data->meta.call_de);
+    if (strlen(tx_msg.msg) > 0) {
+        lv_finder_set_cursor(finder, cell_data->meta.freq_hz);
+        if (!subject_get_int(cfg.ft8_hold_freq.val)) {
+            set_freq(cell_data->meta.freq_hz);
+        }
+        tx_time_slot = !cell_data->odd;
+        subject_set_int(tx_enabled, true);
+        add_info("Start QSO with %s", cell_data->meta.call_de);
+        msg_schedule_text_fmt("Next TX: %s", tx_msg.msg);
+        autosel_recover_mode    = false;
+        qso_tx_exhausted        = false;
+        pending_to_me_valid     = false;
+        pending_grid_to_me_valid= false;
+        autosel_qso_active      = false;
+        autosel_grid_tx_count   = 0;
+        strncpy(qso_active_call, cell_data->meta.call_de, sizeof(qso_active_call) - 1);
+        qso_active_call[sizeof(qso_active_call) - 1] = '\0';
+    } else {
+        msg_schedule_text_fmt("Invalid message");
+        tx_call_off();
+    }
+}
+
+/* table_view actions: ESC -> async dialog destruct, VOL keys -> radio vol. */
+static void on_table_close(void) {
+    lv_async_call(deferred_destruct_cb, NULL);
+}
+static void on_table_vol_change(int32_t delta) {
+    radio_change_vol(delta);
 }
 
 static void keyboard_open() {
@@ -1027,11 +1325,177 @@ static bool keyboard_ok_cb() {
     return true;
 }
 
+#define FT8_FREETEXT_FILE "/mnt/ft8_freetext.txt"
+#define FT8_FREETEXT_MAX_LEN 13
+#define FT8_FREETEXT_ACCEPTED_CHARS " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ+-./?"
+
+static void ft8_freetext_sanitize(const char *in, char *out, size_t out_size) {
+    if (!out || out_size == 0) return;
+    out[0] = '\0';
+    if (!in) return;
+
+    size_t j = 0;
+    for (size_t i = 0; in[i] != '\0'; i++) {
+        char c = in[i];
+        if (c == '\n' || c == '\r') {
+            break;
+        }
+        if (c >= 'a' && c <= 'z') {
+            c = (char)(c - 'a' + 'A');
+        }
+        if (strchr(FT8_FREETEXT_ACCEPTED_CHARS, c) == NULL) {
+            continue;
+        }
+        if (j == 0 && c == ' ') {
+            continue;
+        }
+        if (j + 1 >= out_size) {
+            break;
+        }
+        if (j >= FT8_FREETEXT_MAX_LEN) {
+            break;
+        }
+        out[j++] = c;
+    }
+    while (j > 0 && out[j - 1] == ' ') {
+        j--;
+    }
+    out[j] = '\0';
+}
+
+static void ft8_freetext_load(char *out, size_t out_size) {
+    if (!out || out_size == 0) return;
+    out[0] = '\0';
+
+    FILE *fp = fopen(FT8_FREETEXT_FILE, "r");
+    if (!fp) return;
+
+    char buf[128];
+    buf[0] = '\0';
+    (void)fgets(buf, sizeof(buf), fp);
+    fclose(fp);
+
+    ft8_freetext_sanitize(buf, out, out_size);
+}
+
+static bool ft8_freetext_save(const char *text) {
+    FILE *fp = fopen(FT8_FREETEXT_FILE, "w");
+    if (!fp) return false;
+    if (text && text[0] != '\0') {
+        fputs(text, fp);
+    }
+    fputc('\n', fp);
+    fclose(fp);
+    return true;
+}
+
+static void free_msg_cb(struct button_item_t *btn) {
+    (void)btn;
+    free_msg_open();
+}
+
+static void free_msg_open() {
+    if (!table) {
+        return;
+    }
+
+    lv_group_remove_obj(table);
+    textarea_window_open_w_label(free_msg_ok_cb, free_msg_cancel_cb, "Free MSG");
+    lv_obj_t *text = textarea_window_text();
+
+    lv_textarea_set_one_line(text, true);
+    lv_textarea_set_max_length(text, FT8_FREETEXT_MAX_LEN);
+    lv_textarea_set_accepted_chars(text, FT8_FREETEXT_ACCEPTED_CHARS);
+
+    char def[FT8_FREETEXT_MAX_LEN + 1];
+    ft8_freetext_load(def, sizeof(def));
+    if (def[0] != '\0') {
+        textarea_window_set(def);
+    } else {
+        lv_textarea_set_placeholder_text(text, " FREE TEXT");
+    }
+    disable_buttons = true;
+}
+
+static void free_msg_close() {
+    textarea_window_close();
+    if (table) {
+        lv_group_add_obj(keyboard_group, table);
+        lv_group_set_editing(keyboard_group, true);
+    }
+    disable_buttons = false;
+}
+
+static bool free_msg_cancel_cb() {
+    free_msg_close();
+    return true;
+}
+
+static bool free_msg_ok_cb() {
+    const char *raw = textarea_window_get();
+    char clean[FT8_FREETEXT_MAX_LEN + 1];
+    ft8_freetext_sanitize(raw, clean, sizeof(clean));
+    if (clean[0] == '\0') {
+        msg_schedule_text_fmt("Empty Free MSG");
+        return false;
+    }
+
+    if (!ft8_freetext_save(clean)) {
+        msg_schedule_text_fmt("Save Free MSG failed");
+    }
+
+    if (!qso_processor) {
+        msg_schedule_text_fmt("FT8 not ready");
+        return false;
+    }
+    if (!tx_enabled || !cq_enabled) {
+        msg_schedule_text_fmt("FT8 not ready");
+        return false;
+    }
+
+    if (ftx_qso_processor_has_current(qso_processor)) {
+        msg_schedule_text_fmt("QSO active, cannot Free MSG");
+        return false;
+    }
+    if (tx_msg.msg[0] != '\0') {
+        msg_schedule_text_fmt("TX busy, cannot Free MSG");
+        return false;
+    }
+
+    /* Validate the free-text message fits in a 77-bit FT8 frame. */
+    {
+        ftx_message_t tmp_msg;
+        ftx_message_rc_t rc = ftx_message_encode(&tmp_msg, NULL, clean);
+        if (rc != FTX_MESSAGE_RC_OK) {
+            msg_schedule_text_fmt("Free MSG too long for FT8");
+            return false;
+        }
+    }
+
+    strncpy(tx_msg.msg, clean, sizeof(tx_msg.msg) - 1);
+    tx_msg.msg[sizeof(tx_msg.msg) - 1] = '\0';
+    tx_msg.repeats = 1;
+    tx_msg.force_free_text = true;
+
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME, &now);
+    float time_since_slot_start = 0.0f;
+    tx_time_slot = !get_time_slot(now, &time_since_slot_start);
+    float max_delay = (subject_get_int(cfg.ft8_protocol.val) == FTX_PROTOCOL_FT8) ? MAX_TX_START_DELAY : MAX_TX_START_DELAY_FT4;
+    if (time_since_slot_start < max_delay) {
+        tx_time_slot = !tx_time_slot;
+    }
+
+    subject_set_int(tx_enabled, true);
+    msg_schedule_text_fmt("Next TX: %s", tx_msg.msg);
+
+    free_msg_close();
+    return true;
+}
+
 static void audio_cb(unsigned int n, float complex *samples) {
-    if (state == RX_PROCESS) {
-        pthread_mutex_lock(&audio_mutex);
-        cbuffercf_write(audio_buf, samples, n);
-        pthread_mutex_unlock(&audio_mutex);
+    if (s_audio_worker) {
+        audio_worker_feed(s_audio_worker, n, samples);
     }
 }
 
@@ -1054,114 +1518,29 @@ static bool get_time_slot(struct timespec now, float *sec_since_start) {
 }
 
 
+/* CQ message composer + scheduler module. */
+#include "ft8/cq_scheduler.h"
+
 /**
- * Create CQ TX message
+ * Create CQ TX message - thin wrapper around cq_make_message().
  */
 static void make_cq_msg(const char *callsign, const char *qth, const char *cq_mod, char *text) {
-    size_t text_len;
-    char buf[128];
-    if (strlen(cq_mod)) {
-        snprintf(buf, FTX_MAX_MESSAGE_LENGTH, "CQ_%s %s %.4s", cq_mod, callsign, qth);
-    } else {
-        snprintf(buf, FTX_MAX_MESSAGE_LENGTH, "CQ %s %.4s", callsign, qth);
-    }
-
-    ftx_message_rc_t rc;
-    ftx_message_t msg;
-    rc = ftx_message_encode(&msg, NULL, buf);
-    if (rc != FTX_MESSAGE_RC_OK) {
-        LV_LOG_USER("Error: %d while encoding message: '%s'", rc, buf);
-    }
-    rc = ftx_message_decode(&msg, NULL, buf);
-    if (rc != FTX_MESSAGE_RC_OK) {
-        LV_LOG_USER("Error: %d while decoding message: '%s'", rc, buf);
-    }
-    strcpy(text, buf);
+    cq_make_message(callsign, qth, cq_mod,
+                    text, FTX_MAX_MESSAGE_LENGTH,
+                    subject_get_int(cfg.ft8_omit_cq_qth.val));
 }
 
-/**
- * Get output level correction, based on output power and ALC
- */
-static float get_correction() {
-    static uint8_t msg_id = 0;
-    float correction = 0.0f;
-    float pwr, alc;
+/* Bridge to ft8/tx_worker.c - the actual TX play loop and ALC-driven gain
+ * correction live there. tx_call_off() requests an abort via the module's
+ * atomic flag (replaces the old `state != TX_PROCESS` early-out). */
+#include "ft8/tx_worker.h"
 
-    if (tx_info_refresh(&msg_id, &alc, &pwr, NULL)) {
-        float target_pwr = LV_MIN(subject_get_float(cfg.pwr.val), MAX_PWR);
-        if (alc > 0.5f) {
-            correction = log10f(log10f(11.1f - alc)) * 20.0f - 0.38f;
-        } else if (target_pwr - pwr > 0.5f) {
-            // TODO: check battery level
-            correction = log10f(target_pwr / (pwr + 0.01f)) * 10.0f;
-        }
-    }
-    return correction;
-}
-
-static void tx_worker() {
-    const uint16_t signal_freq = 1325;
-    int16_t       *samples;
-    uint32_t       n_samples;
-
-    if (!ftx_worker_generate_tx_samples(tx_msg.msg, signal_freq, AUDIO_PLAY_RATE, &samples, &n_samples)) {
-        state = RX_PROCESS;
-        return;
-    }
-    if (subject_get_float(cfg.pwr.val) > MAX_PWR) {
-        radio_set_pwr(MAX_PWR);
-    }
-
-    float gain_offset = base_gain_offset + params.ft8_output_gain_offset.x;
-    float play_gain_offset = audio_set_play_vol(gain_offset + 6.0f);
-    gain_offset -= play_gain_offset;
-
-    // Change freq before tx
-    uint64_t radio_freq = subject_get_int(cfg_cur.fg_freq);
-    radio_set_freq(radio_freq + params.ft8_tx_freq.x - signal_freq);
-    radio_set_modem(true);
-
-    float    prev_gain_offset = gain_offset;
-    size_t   counter = 0;
-    int16_t *ptr = samples;
-    size_t   part;
-
-    while (true) {
-        if (counter > 30) {
-            gain_offset += get_correction() * 0.4f;
-
-            if (gain_offset > 0.0)
-                gain_offset = 0.0f;
-            else if (gain_offset < -30.0f)
-                gain_offset = -30.0f;
-        }
-        if (n_samples <= 0 || state != TX_PROCESS) {
-            state = RX_PROCESS;
-            break;
-        }
-        part = LV_MIN(1024 * 2, n_samples);
-        if (gain_offset == prev_gain_offset) {
-            if (gain_offset != 0.0f) {
-                audio_gain_db(ptr, part, gain_offset, ptr);
-            }
-        } else {
-            // Smooth change gain
-            audio_gain_db_transition(ptr, part, prev_gain_offset, gain_offset, ptr);
-            prev_gain_offset = gain_offset;
-        }
-        audio_play(ptr, part);
-
-        n_samples -= part;
-        ptr += part;
-        counter++;
-    }
-    params_float_set(&params.ft8_output_gain_offset, gain_offset - base_gain_offset + play_gain_offset);
-    audio_play_wait();
-    radio_set_modem(false);
-    // Restore freq
-    radio_set_freq(radio_freq);
-    free(samples);
-    audio_set_play_vol(params.play_gain_db_f.x);
+static void tx_worker(float sec_since_slot_start) {
+    tx_worker_clear_abort();
+    tx_worker_run(tx_msg.msg, tx_msg.force_free_text,
+                  AUDIO_PLAY_RATE, base_gain_offset,
+                  sec_since_slot_start);
+    state = RX_PROCESS;
 }
 
 /**
@@ -1169,53 +1548,101 @@ static void tx_worker() {
  */
 static void add_info(const char * fmt, ...) {
     va_list     args;
-    cell_data_t  cell_data;
+    cell_data_t  cell_data = {0};
     cell_data.cell_type = CELL_RX_INFO;
 
     va_start(args, fmt);
     vsnprintf(cell_data.text, sizeof(cell_data.text), fmt, args);
     va_end(args);
+    cell_data.text[sizeof(cell_data.text) - 1] = '\0';
 
-    scheduler_put(add_msg_cb, &cell_data, sizeof(cell_data_t));
+    scheduler_put(table_view_add_msg_cb, &cell_data, sizeof(cell_data_t));
 }
-
-/**
- * Add TX message to the table
- */
 static void add_tx_text(const char * text) {
-    cell_data_t  cell_data;
+    cell_data_t  cell_data = {0};
     cell_data.cell_type = CELL_TX_MSG;
 
     strncpy(cell_data.text, text, sizeof(cell_data.text) - 1);
+    cell_data.text[sizeof(cell_data.text) - 1] = '\0';
     if (strncmp(cell_data.text, "CQ_", 3) == 0) {
         cell_data.text[2] = ' ';
     }
-    scheduler_put(add_msg_cb, &cell_data, sizeof(cell_data_t));
+    scheduler_put(table_view_add_msg_cb, &cell_data, sizeof(cell_data_t));
 }
 
-/**
- * Parse and add RX messages to the table
- */
 static void add_rx_text(int16_t snr, const char * text, slot_info_t *s_info, float freq_hz, float time_sec) {
-
-    ftx_msg_meta_t meta;
+    bool had_qso = ftx_qso_processor_has_current(qso_processor);
+    ftx_msg_meta_t meta = {0};
     meta.freq_hz = freq_hz;
     meta.time_sec = time_sec;
     char * old_msg = strdup(tx_msg.msg);
+    bool old_msg_alloced = true;
+    if (!old_msg) {
+        old_msg = "";
+        old_msg_alloced = false;
+    }
     ftx_qso_processor_add_rx_text(qso_processor, text, snr, &meta, &tx_msg);
 
+    if (!had_qso && ftx_qso_processor_has_current(qso_processor) && s_info) {
+        ft8_log_qso(s_info->slot_start, meta.call_de);
+    }
+
     if ((strlen(tx_msg.msg) > 0) && (strcmp(old_msg, tx_msg.msg) != 0)) {
-        lv_finder_set_cursor(finder, meta.freq_hz);
+        tx_msg.force_free_text = false;
+        finder_set_cursor_async(meta.freq_hz);
         if (!subject_get_int(cfg.ft8_hold_freq.val)) {
             set_freq(freq_hz);
         }
         tx_time_slot = !s_info->odd;
         msg_schedule_text_fmt("Next TX: %s", tx_msg.msg);
+        if (meta.to_me && (meta.call_de[0] != '\0')) {
+            strncpy(qso_active_call, meta.call_de, sizeof(qso_active_call) - 1);
+            qso_active_call[sizeof(qso_active_call) - 1] = '\0';
+        }
         if (subject_get_int(cq_enabled)) {
+            /* Pause CQ while handling this QSO so we don't keep CQing others.
+             * Remember that CQ was enabled so we can restore it after QSO.
+             */
+            cq_paused_for_qso = true;
             subject_set_int(cq_enabled, false);
         }
+
+        /* Any new outgoing message means we're no longer in the "TX exhausted" state. */
+        qso_tx_exhausted = false;
+        autosel_recover_mode = false;
+
+        /* If TX message changed (progress), reset AutoSel grid tracking. */
+        autosel_grid_tx_count = 0;
+        pending_grid_to_me_valid = false;
     }
-    free(old_msg);
+    if (old_msg_alloced) free(old_msg);
+
+    /* Priority (2): after TX is exhausted, if another station calls to me,
+     * remember it so rx_worker() can switch QSO before AutoSel.
+     */
+    if (qso_tx_exhausted && meta.to_me && (meta.call_de[0] != '\0')) {
+        if ((qso_active_call[0] == '\0') || (strcmp(qso_active_call, meta.call_de) != 0)) {
+            if (!pending_to_me_valid) {
+                pending_to_me_meta = meta;
+                pending_to_me_odd = s_info->odd;
+                pending_to_me_valid = true;
+            }
+        }
+    }
+
+    /* Priority (grid-stage): while AutoSel is repeatedly sending our grid to a CQ caller,
+     * remember the first other station that sends a GRID message to us.
+     * This is acted upon at the start of the 3rd grid TX.
+     */
+    if (autosel_qso_active && is_grid_exchange_msg(tx_msg.msg) && meta.to_me && (meta.type == FTX_MSG_TYPE_GRID) && (meta.call_de[0] != '\0')) {
+        if ((qso_active_call[0] == '\0') || (strcmp(qso_active_call, meta.call_de) != 0)) {
+            if (!pending_grid_to_me_valid) {
+                pending_grid_to_me_meta = meta;
+                pending_grid_to_me_odd = s_info->odd;
+                pending_grid_to_me_valid = true;
+            }
+        }
+    }
 
     ft8_cell_type_t cell_type;
     if (meta.to_me) {
@@ -1228,7 +1655,7 @@ static void add_rx_text(int16_t snr, const char * text, slot_info_t *s_info, flo
         cell_type = CELL_RX_MSG;
     }
 
-    cell_data_t  cell_data;
+    cell_data_t  cell_data = {0};
     if (meta.type == FTX_MSG_TYPE_CQ) {
         cell_data.worked_type = qso_log_search_worked(
             meta.call_de,
@@ -1237,117 +1664,66 @@ static void add_rx_text(int16_t snr, const char * text, slot_info_t *s_info, flo
         );
     }
 
+    /* Collect unseen CQ callers for auto-selection if we're not in a QSO.
+     * Compute distance first and only collect when AutoSel is enabled.
+     * Use local_qth_valid to ensure we don't use (0,0) as a false valid position. */
+    int computed_dist = 0;
+    if (local_qth_valid && strlen(meta.grid) > 0 && qth_grid_check(meta.grid)) {
+        double lat, lon;
+        qth_str_to_pos(meta.grid, &lat, &lon);
+        computed_dist = (int) qth_pos_dist(lat, lon, cur_lat, cur_lon);
+    }
+    if ((meta.type == FTX_MSG_TYPE_CQ) && !meta.to_me) {
+        /* Track CQ activity for blacklisted stations so they only clear after
+         * X consecutive cycles of not being heard CQ'ing.
+         */
+        autosel_blacklist_mark_seen(meta.call_de);
+        if ((auto_sel_mode != AUTO_SEL_OFF) &&
+            (!ftx_qso_processor_has_current(qso_processor) || autosel_recover_mode)
+        ) {
+            autosel_add_candidate(&meta, computed_dist, meta.local_snr);
+        }
+    }
+
     cell_data.cell_type = cell_type;
     strncpy(cell_data.text, text, sizeof(cell_data.text) - 1);
+    cell_data.text[sizeof(cell_data.text) - 1] = '\0';
     cell_data.meta = meta;
     cell_data.odd = s_info->odd;
-    if (params.qth.x[0] != 0) {
-        if (strlen(meta.grid) > 0) {
-            double lat, lon;
-            qth_str_to_pos(meta.grid, &lat, &lon);
-            cell_data.dist = qth_pos_dist(lat, lon, cur_lat, cur_lon);
-        } else {
-            cell_data.dist = 0;
-        }
+    /* assign computed distance for display */
+    if (local_qth_valid) {
+        cell_data.dist = computed_dist;
     } else {
         cell_data.dist = 0;
     }
-    scheduler_put(add_msg_cb, (void*)&cell_data, sizeof(cell_data_t));
+    /* Prefix '*' before grid if this grid hasn't been worked yet (DB check) */
+    if (meta.grid[0] != '\0') {
+        bool grid_worked = qso_log_search_worked_grid(
+            meta.grid,
+            subject_get_int(cfg.ft8_protocol.val) == FTX_PROTOCOL_FT8 ? MODE_FT8 : MODE_FT4,
+            qso_log_freq_to_band(subject_get_int(cfg_cur.fg_freq))
+        );
+        if (!grid_worked) {
+            char tmp[64];
+            char *pos = strstr(cell_data.text, meta.grid);
+            if (pos) {
+                size_t prefix_len = pos - cell_data.text;
+                if (prefix_len >= sizeof(tmp) - 2) prefix_len = sizeof(tmp) - 3;
+                snprintf(tmp, sizeof(tmp), "%.*s*%s", (int)prefix_len, cell_data.text, pos);
+            } else {
+                snprintf(tmp, sizeof(tmp), "*%s", cell_data.text);
+            }
+            strncpy(cell_data.text, tmp, sizeof(cell_data.text) - 1);
+            cell_data.text[sizeof(cell_data.text) - 1] = '\0';
+        }
+    }
+    scheduler_put(table_view_add_msg_cb, (void*)&cell_data, sizeof(cell_data_t));
 }
 
 static void received_message_cb(const char *text, int snr, float freq_hz, float time_sec, void *user_data) {
     slot_info_t *s_info = (slot_info_t *)user_data;
+    ft8_log_rx_collect(s_info, freq_hz, snr, text);
     add_rx_text(snr, text, s_info, freq_hz, time_sec);
 }
 
-static void rx_worker(bool new_slot, slot_info_t *s_info) {
-    unsigned int   n;
-    float complex *buf;
-    const int block_size = ftx_worker_get_block_size();
-    const size_t   size = block_size * DECIM;
 
-    pthread_mutex_lock(&audio_mutex);
-
-    while (cbuffercf_size(audio_buf) > size) {
-        cbuffercf_read(audio_buf, size, &buf, &n);
-
-        firdecim_crcf_execute_block(decim, buf, block_size, decim_buf);
-        cbuffercf_release(audio_buf, size);
-
-        waterfall_process(decim_buf, block_size);
-
-        ftx_worker_put_rx_samples(decim_buf, block_size);
-
-        if (ftx_worker_is_full()) {
-            ftx_worker_decode(received_message_cb, true, (void *)s_info);
-            ftx_worker_reset();
-        } else {
-            ftx_worker_decode(received_message_cb, false, (void *)s_info);
-        }
-    }
-    pthread_mutex_unlock(&audio_mutex);
-
-    if (new_slot) {
-        ftx_worker_decode(received_message_cb, true, (void *)s_info);
-        ftx_worker_reset();
-        ftx_qso_processor_start_new_slot(qso_processor);
-    }
-}
-
-static void * decode_thread(void *arg) {
-    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
-    pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
-
-    struct timespec now;
-    struct timespec slot_start_ts;
-    bool            new_odd;
-    struct tm      *ts;
-    float           sec_since_slot_start;
-    bool            new_slot    = false;
-    bool            have_tx_msg = false;
-
-    slot_info_t s_info = {.odd=false, .answer_generated=false};
-
-    while (true) {
-        clock_gettime(CLOCK_REALTIME, &now);
-        new_odd = get_time_slot(now, &sec_since_slot_start);
-        new_slot = new_odd != s_info.odd;
-        rx_worker(new_slot, &s_info);
-        s_info.odd = new_odd;
-
-        have_tx_msg = tx_msg.msg[0] != '\0';
-
-        if ((sec_since_slot_start < MAX_TX_START_DELAY) && have_tx_msg) {
-            // Start TX and continue after done
-            if ((tx_time_slot == new_odd) && subject_get_int(tx_enabled)) {
-                state = TX_PROCESS;
-                add_tx_text(tx_msg.msg);
-                tx_worker();
-                if (tx_msg.repeats > 0) {
-                    tx_msg.repeats--;
-                }
-                if (tx_msg.repeats == 0){
-                    if (strncmp(tx_msg.msg, "CQ", 2) == 0) {
-                        subject_set_int(cq_enabled, false);
-                    }
-                    tx_msg.msg[0] = '\0';
-                }
-                continue;
-            }
-        }
-
-        if (new_slot) {
-            // Add message about new slot;
-            state = RX_PROCESS;
-            if ((!have_tx_msg || !subject_get_int(tx_enabled))) {
-                ts = localtime(&now.tv_sec);
-                add_info("RX %s %02i:%02i:%02i", cfg_digital_label_get(),
-                    ts->tm_hour, ts->tm_min, ts->tm_sec);
-            }
-        } else {
-            usleep(100000);
-        }
-    }
-
-    return NULL;
-}

--- a/src/dsp.cpp
+++ b/src/dsp.cpp
@@ -14,6 +14,7 @@
 #include "cfg/subjects.h"
 
 #include <algorithm>
+#include <atomic>
 #include <numeric>
 
 extern "C" {
@@ -72,6 +73,9 @@ static float          waterfall_psd_lin[WATERFALL_NFFT];
 static float          waterfall_psd[WATERFALL_NFFT];
 static uint8_t        waterfall_fps_ms = (1000 / 15);
 static uint64_t       waterfall_time;
+
+static std::atomic<bool> waterfall_enabled{true};
+static std::atomic<bool> spectrum_enabled{true};
 
 static cfloat buf_filtered[RADIO_SAMPLES * 2];
 
@@ -335,18 +339,20 @@ static void process_samples(cfloat *buf_samples, uint16_t size, firdecim_crcf sp
     size_t wf_n_samples = size;
     size_t sp_n_samples = size;
 
-    if ((spectrum_factor > 1) && !fw_decim) {
-        sp_n_samples = size / spectrum_factor;
-        firdecim_crcf_execute_block(sp_decim, buf_filtered, sp_n_samples, spectrum_dec_buf);
-        sp_sg->execute_block(spectrum_dec_buf, sp_n_samples);
-        if (waterfall_fft_decim) {
-            samples_for_wf = spectrum_dec_buf;
-            wf_n_samples = sp_n_samples;
+    if (spectrum_enabled.load(std::memory_order_relaxed)) {
+        if ((spectrum_factor > 1) && !fw_decim) {
+            sp_n_samples = size / spectrum_factor;
+            firdecim_crcf_execute_block(sp_decim, buf_filtered, sp_n_samples, spectrum_dec_buf);
+            sp_sg->execute_block(spectrum_dec_buf, sp_n_samples);
+            if (waterfall_fft_decim) {
+                samples_for_wf = spectrum_dec_buf;
+                wf_n_samples = sp_n_samples;
+            }
+        } else {
+            sp_sg->execute_block(buf_filtered, sp_n_samples);
         }
-    } else {
-        sp_sg->execute_block(buf_filtered, sp_n_samples);
     }
-    if (wf_sg) {
+    if (wf_sg && waterfall_enabled.load(std::memory_order_relaxed)) {
         wf_sg->execute_block(samples_for_wf, wf_n_samples);
     }
 }
@@ -473,9 +479,11 @@ void dsp_samples(cfloat *buf_samples, uint16_t size, bool tx, uint32_t base_freq
         wf_sg = NULL;
     }
     process_samples(buf_samples, size, sp_decim, sp_sg, wf_sg, tx);
-    update_spectrum(sp_sg, now, tx, base_freq);
+    if (spectrum_enabled.load(std::memory_order_relaxed)) {
+        update_spectrum(sp_sg, now, tx, base_freq);
+    }
     pthread_mutex_unlock(&spectrum_mux);
-    if (wf_sg) {
+    if (wf_sg && waterfall_enabled.load(std::memory_order_relaxed)) {
         if (update_waterfall(wf_sg, now, tx, base_freq)) {
             update_s_meter();
             // TODO: skip on disabled auto min/max
@@ -665,9 +673,17 @@ static void dsp_update_min_max(float *data_buf, uint16_t size) {
 
 extern "C" {
 void dsp_set_waterfall_enabled(bool enabled) {
-    (void)enabled;
+    waterfall_enabled.store(enabled, std::memory_order_relaxed);
+    if (enabled) {
+        psd_delay = 4;
+        waterfall_time = get_time();
+    }
 }
 void dsp_set_spectrum_enabled(bool enabled) {
-    (void)enabled;
+    spectrum_enabled.store(enabled, std::memory_order_relaxed);
+    if (enabled) {
+        psd_delay = 4;
+        spectrum_time = get_time();
+    }
 }
 }

--- a/src/dsp.cpp
+++ b/src/dsp.cpp
@@ -662,3 +662,12 @@ static void dsp_update_min_max(float *data_buf, uint16_t size) {
     spectrum_update_max(max);
     waterfall_update_max(max);
 }
+
+extern "C" {
+void dsp_set_waterfall_enabled(bool enabled) {
+    (void)enabled;
+}
+void dsp_set_spectrum_enabled(bool enabled) {
+    (void)enabled;
+}
+}

--- a/src/dsp.h
+++ b/src/dsp.h
@@ -75,6 +75,8 @@ void dsp_samples(cfloat *buf_samples, uint16_t size, bool tx, uint32_t base_freq
 void dsp_reset();
 
 float dsp_get_spectrum_beta();
+void dsp_set_waterfall_enabled(bool enabled);
+void dsp_set_spectrum_enabled(bool enabled);
 void dsp_set_spectrum_beta(float x);
 
 void dsp_put_audio_samples(size_t nsamples, int16_t *samples);

--- a/src/ft8/CMakeLists.txt
+++ b/src/ft8/CMakeLists.txt
@@ -1,4 +1,8 @@
-add_library(FT8 STATIC qso.cpp worker.c utils.c gfsk.c)
+add_library(FT8 STATIC
+    qso.cpp worker.c utils.c gfsk.c
+    ft8_log.c params.c
+    table_view.c audio_worker.c auto_dnf.c
+    auto_sel.cpp qso_state.c tx_worker.c cq_scheduler.c
+)
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../qth")
-

--- a/src/ft8/audio_worker.c
+++ b/src/ft8/audio_worker.c
@@ -1,0 +1,356 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 audio / decode worker
+ *
+ *  Copyright (c) 2026
+ */
+
+#include "audio_worker.h"
+
+#include <errno.h>
+#include <math.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <liquid/liquid.h>
+#include <ft8lib/constants.h>
+
+#include "worker.h"
+
+/* Waterfall display width in pixels; used to size the FFT so each pixel maps
+ * to one bin over the visible band. Matches dialog_ft8.c. */
+#define WORKER_DISPLAY_WIDTH   771
+
+struct audio_worker_s {
+    /* Configuration (const after create). */
+    int            sample_rate;       /* audio_sample_rate */
+    int            decim;             /* decim_ratio */
+    int            worker_rate;       /* sample_rate / decim */
+    ftx_protocol_t proto;
+    int32_t        filter_low_hz;
+    int32_t        filter_high_hz;
+    uint16_t       nfft;
+    uint8_t        fps_ms;            /* min interval between PSD emissions */
+
+    audio_worker_cb_t cb;
+
+    /* Thread lifecycle. */
+    pthread_t       thread;
+    atomic_bool     stop_req;
+    atomic_bool     thread_running;
+    pthread_mutex_t sleep_mux;
+    pthread_cond_t  sleep_cv;
+
+    /* Audio buffer (written by audio_worker_feed, read by worker). */
+    pthread_mutex_t audio_mux;
+    cbuffercf       audio_buf;
+
+    /* DSP state (worker thread only). */
+    firdecim_crcf   decim_dsp;
+    spgramcf        sg;
+    float          *psd;
+    float complex  *audio_frame_buf;
+    size_t          audio_frame_buf_len;
+    float complex  *decim_buf;
+    int             block_size;
+
+    uint64_t        last_psd_time_ms;
+};
+
+/* ---------- small helpers ---------------------------------------------- */
+
+static uint64_t now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000ULL + (uint64_t)(ts.tv_nsec / 1000000L);
+}
+
+static bool get_time_slot(ftx_protocol_t proto, struct timespec now, float *sec_since_start) {
+    float sec = (now.tv_sec % 60) + now.tv_nsec / 1.0e9f;
+    float slot_time = (proto == FTX_PROTOCOL_FT4) ? FT4_SLOT_TIME : FT8_SLOT_TIME;
+    *sec_since_start = fmodf(sec, slot_time);
+    return ((int)(sec / slot_time) % 2) != 0;
+}
+
+static void msleep_interruptible(audio_worker_t *w, long ms) {
+    struct timespec abstime;
+    clock_gettime(CLOCK_REALTIME, &abstime);
+    abstime.tv_sec  += ms / 1000;
+    abstime.tv_nsec += (ms % 1000) * 1000000L;
+    if (abstime.tv_nsec >= 1000000000L) {
+        abstime.tv_sec  += 1;
+        abstime.tv_nsec -= 1000000000L;
+    }
+    pthread_mutex_lock(&w->sleep_mux);
+    if (!atomic_load(&w->stop_req)) {
+        pthread_cond_timedwait(&w->sleep_cv, &w->sleep_mux, &abstime);
+    }
+    pthread_mutex_unlock(&w->sleep_mux);
+}
+
+static void drain_audio_buf(audio_worker_t *w) {
+    pthread_mutex_lock(&w->audio_mux);
+    if (w->audio_buf) {
+        unsigned int sz = cbuffercf_size(w->audio_buf);
+        if (sz > 0) cbuffercf_release(w->audio_buf, sz);
+    }
+    pthread_mutex_unlock(&w->audio_mux);
+}
+
+/* ---------- PSD / waterfall ------------------------------------------- */
+
+static void maybe_emit_psd(audio_worker_t *w, const slot_info_t *info,
+                           float sec_since_slot_start) {
+    uint64_t now = now_ms();
+    if ((now - w->last_psd_time_ms) < w->fps_ms) return;
+    w->last_psd_time_ms = now;
+
+    spgramcf_get_psd(w->sg, w->psd);
+    liquid_vectorf_addscalar(w->psd, w->nfft,
+                             -10.f * log10f(sqrtf((float)w->nfft)),
+                             w->psd);
+
+    if (w->cb.on_psd) {
+        w->cb.on_psd(w->psd, w->nfft, sec_since_slot_start, info, w->cb.ctx);
+    }
+
+    spgramcf_reset(w->sg);
+}
+
+/* ---------- ftx_worker decode callback trampoline --------------------- */
+
+typedef struct {
+    audio_worker_t    *w;
+    const slot_info_t *info;
+} decode_ctx_t;
+
+static void decode_cb(const char *text, int snr, float freq_hz, float time_sec, void *user) {
+    decode_ctx_t *dc = (decode_ctx_t *)user;
+    if (dc && dc->w && dc->w->cb.on_message) {
+        dc->w->cb.on_message(text, snr, freq_hz, time_sec, dc->info, dc->w->cb.ctx);
+    }
+}
+
+/* ---------- RX frame pump --------------------------------------------- */
+
+static void rx_consume_frames(audio_worker_t *w, const slot_info_t *info,
+                              float sec_since_slot_start) {
+    const size_t need = (size_t)w->block_size * (size_t)w->decim;
+    decode_ctx_t dc = { .w = w, .info = info };
+
+    for (;;) {
+        if (atomic_load(&w->stop_req)) return;
+
+        bool           has_frame = false;
+        bool           copied    = false;
+        unsigned int   got       = 0;
+        float complex *src       = NULL;
+
+        pthread_mutex_lock(&w->audio_mux);
+        if (cbuffercf_size(w->audio_buf) > (unsigned int)need) {
+            has_frame = true;
+            cbuffercf_read(w->audio_buf, (unsigned int)need, &src, &got);
+            if (w->audio_frame_buf && (w->audio_frame_buf_len >= need) && ((size_t)got >= need)) {
+                memcpy(w->audio_frame_buf, src, need * sizeof(float complex));
+                copied = true;
+            }
+            cbuffercf_release(w->audio_buf, (unsigned int)need);
+        }
+        pthread_mutex_unlock(&w->audio_mux);
+
+        if (!has_frame) break;
+        if (!copied)    continue;
+
+        firdecim_crcf_execute_block(w->decim_dsp, w->audio_frame_buf,
+                                    w->block_size, w->decim_buf);
+
+        spgramcf_write(w->sg, w->decim_buf, (unsigned int)w->block_size);
+        maybe_emit_psd(w, info, sec_since_slot_start);
+
+        ftx_worker_put_rx_samples(w->decim_buf, w->block_size);
+
+        if (ftx_worker_is_full()) {
+            ftx_worker_decode(decode_cb, true, (void *)&dc);
+            ftx_worker_reset();
+        } else {
+            ftx_worker_decode(decode_cb, false, (void *)&dc);
+        }
+    }
+}
+
+/* ---------- thread body ---------------------------------------------- */
+
+static void *worker_main(void *arg) {
+    audio_worker_t *w = (audio_worker_t *)arg;
+    slot_info_t     info = { .odd = false, .answer_generated = false };
+    decode_ctx_t    dc   = { .w = w, .info = &info };
+
+    atomic_store(&w->thread_running, true);
+
+    while (!atomic_load(&w->stop_req)) {
+        struct timespec now;
+        clock_gettime(CLOCK_REALTIME, &now);
+
+        float sec_since_slot_start = 0.0f;
+        bool  new_odd  = get_time_slot(w->proto, now, &sec_since_slot_start);
+        bool  new_slot = (new_odd != info.odd);
+
+        float  slot_period = (w->proto == FTX_PROTOCOL_FT4) ? FT4_SLOT_TIME : FT8_SLOT_TIME;
+        double now_f       = (double)now.tv_sec + (double)now.tv_nsec / 1.0e9;
+        double slot_start_f = now_f - (double)sec_since_slot_start;
+        if (new_slot) slot_start_f -= (double)slot_period;
+        info.slot_start = (time_t)slot_start_f;
+
+        rx_consume_frames(w, &info, sec_since_slot_start);
+
+        if (new_slot) {
+            /* Slot boundary: flush a final decode, drain stale audio that
+             * accumulated during TX, and fire the slot_end handler. */
+            ftx_worker_decode(decode_cb, true, (void *)&dc);
+            ftx_worker_reset();
+            drain_audio_buf(w);
+
+            if (w->cb.on_slot_end) {
+                w->cb.on_slot_end(&info, w->cb.ctx);
+            }
+            info.odd = new_odd;
+        }
+
+        if (w->cb.on_tick) {
+            w->cb.on_tick(&info, new_slot, sec_since_slot_start, w->cb.ctx);
+        }
+
+        if (!new_slot && !atomic_load(&w->stop_req)) {
+            msleep_interruptible(w, 100);
+        }
+    }
+
+    atomic_store(&w->thread_running, false);
+    return NULL;
+}
+
+/* ---------- public API ------------------------------------------------- */
+
+audio_worker_t *audio_worker_create(int audio_sample_rate,
+                                    int decim_ratio,
+                                    ftx_protocol_t proto,
+                                    int32_t filter_low_hz,
+                                    int32_t filter_high_hz,
+                                    const audio_worker_cb_t *cb) {
+    if ((decim_ratio <= 0) || (audio_sample_rate <= 0)) return NULL;
+    int span = filter_high_hz - filter_low_hz;
+    if (span <= 0) return NULL;
+
+    audio_worker_t *w = (audio_worker_t *)calloc(1, sizeof(*w));
+    if (!w) return NULL;
+
+    w->sample_rate    = audio_sample_rate;
+    w->decim          = decim_ratio;
+    w->worker_rate    = audio_sample_rate / decim_ratio;
+    w->proto          = proto;
+    w->filter_low_hz  = filter_low_hz;
+    w->filter_high_hz = filter_high_hz;
+    w->nfft           = (uint16_t)(WORKER_DISPLAY_WIDTH * w->worker_rate / span);
+    w->fps_ms         = (uint8_t)(1000 / 5);   /* 5 Hz update cap */
+    if (cb) w->cb = *cb;
+
+    pthread_mutex_init(&w->audio_mux, NULL);
+    pthread_mutex_init(&w->sleep_mux, NULL);
+    pthread_cond_init(&w->sleep_cv, NULL);
+
+    w->audio_buf = cbuffercf_create((unsigned int)(audio_sample_rate * 3));
+    if (!w->audio_buf) goto fail;
+
+    w->decim_dsp = firdecim_crcf_create_kaiser((unsigned int)decim_ratio, 8, 40.0f);
+    if (!w->decim_dsp) goto fail;
+    firdecim_crcf_set_scale(w->decim_dsp, 1.0f / (float)decim_ratio);
+
+    w->sg = spgramcf_create(w->nfft, LIQUID_WINDOW_HANN, w->nfft, w->nfft / 2);
+    if (!w->sg) goto fail;
+
+    w->psd = (float *)malloc(w->nfft * sizeof(float));
+    if (!w->psd) goto fail;
+
+    ftx_worker_init(w->worker_rate, proto);
+    w->block_size          = ftx_worker_get_block_size();
+    if (w->block_size <= 0) goto fail;
+
+    w->audio_frame_buf_len = (size_t)w->block_size * (size_t)decim_ratio;
+    w->audio_frame_buf     = (float complex *)malloc(w->audio_frame_buf_len * sizeof(float complex));
+    w->decim_buf           = (float complex *)malloc((size_t)w->block_size * sizeof(float complex));
+    if (!w->audio_frame_buf || !w->decim_buf) goto fail;
+
+    atomic_store(&w->stop_req, false);
+    atomic_store(&w->thread_running, false);
+
+    return w;
+
+fail:
+    audio_worker_destroy(w);
+    return NULL;
+}
+
+int audio_worker_start(audio_worker_t *w) {
+    if (!w) return -1;
+    atomic_store(&w->stop_req, false);
+    if (pthread_create(&w->thread, NULL, worker_main, w) != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+void audio_worker_stop(audio_worker_t *w) {
+    if (!w) return;
+    atomic_store(&w->stop_req, true);
+    pthread_mutex_lock(&w->sleep_mux);
+    pthread_cond_broadcast(&w->sleep_cv);
+    pthread_mutex_unlock(&w->sleep_mux);
+
+    if (atomic_load(&w->thread_running)) {
+        pthread_join(w->thread, NULL);
+    } else {
+        /* Thread may have been created but not yet atomically flipped the
+         * running flag, or start was never called. pthread_join is still
+         * safe when the thread has actually been created. */
+    }
+    atomic_store(&w->thread_running, false);
+}
+
+void audio_worker_destroy(audio_worker_t *w) {
+    if (!w) return;
+    audio_worker_stop(w);
+
+    if (w->audio_frame_buf) { free(w->audio_frame_buf); w->audio_frame_buf = NULL; }
+    if (w->decim_buf)       { free(w->decim_buf);       w->decim_buf = NULL; }
+    if (w->psd)             { free(w->psd);             w->psd = NULL; }
+
+    if (w->sg)        { spgramcf_destroy(w->sg);              w->sg = NULL; }
+    if (w->decim_dsp) { firdecim_crcf_destroy(w->decim_dsp);  w->decim_dsp = NULL; }
+    if (w->audio_buf) { cbuffercf_destroy(w->audio_buf);      w->audio_buf = NULL; }
+
+    ftx_worker_free();
+
+    pthread_mutex_destroy(&w->audio_mux);
+    pthread_mutex_destroy(&w->sleep_mux);
+    pthread_cond_destroy(&w->sleep_cv);
+
+    free(w);
+}
+
+void audio_worker_feed(audio_worker_t *w, unsigned int n, float complex *samples) {
+    if (!w || !samples || (n == 0)) return;
+    pthread_mutex_lock(&w->audio_mux);
+    if (w->audio_buf) {
+        cbuffercf_write(w->audio_buf, samples, n);
+    }
+    pthread_mutex_unlock(&w->audio_mux);
+}
+
+uint16_t audio_worker_nfft(const audio_worker_t *w) {
+    return w ? w->nfft : 0;
+}

--- a/src/ft8/audio_worker.c
+++ b/src/ft8/audio_worker.c
@@ -204,7 +204,7 @@ static void *worker_main(void *arg) {
         double now_f       = (double)now.tv_sec + (double)now.tv_nsec / 1.0e9;
         double slot_start_f = now_f - (double)sec_since_slot_start;
         if (new_slot) slot_start_f -= (double)slot_period;
-        info.slot_start = (time_t)slot_start_f;
+        info.slot_start = (time_t)llround(slot_start_f);
 
         rx_consume_frames(w, &info, sec_since_slot_start);
 

--- a/src/ft8/audio_worker.h
+++ b/src/ft8/audio_worker.h
@@ -1,0 +1,88 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 audio / decode worker
+ *
+ *  Copyright (c) 2026
+ */
+
+/*
+ *  Owns the FT8 decoder thread and the realtime audio ring buffer that
+ *  feeds it. Uses cooperative shutdown via an atomic stop flag plus a
+ *  condition variable - never pthread_cancel. When audio_worker_stop()
+ *  returns, all DSP state (ftx_worker, firdecim, spgramcf) is in a
+ *  consistent state, so ftx_worker_free() is safe.
+ *
+ *  Business logic hooks are pure callbacks with value-semantic payloads:
+ *
+ *      on_message   - one FT8/FT4 decode (may fire 0..N times per iteration)
+ *      on_psd       - one waterfall PSD frame
+ *      on_slot_end  - slot boundary crossed, RX window closed, decoder reset
+ *      on_tick      - end-of-iteration hook, caller may perform blocking TX
+ *
+ *  All callbacks run on the worker thread. Handlers that need to touch LVGL
+ *  must scheduler_put() into the UI thread instead of poking LVGL directly.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <complex.h>
+
+#include <ft8lib/constants.h>
+
+#include "ft8_log.h"   /* slot_info_t */
+#include "qso.h"       /* ftx_msg_meta_t */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct audio_worker_s audio_worker_t;
+
+typedef struct {
+    void (*on_message)(const char *text, int snr, float freq_hz,
+                       float time_sec,
+                       const slot_info_t *info, void *ctx);
+    void (*on_psd)(const float *psd, uint16_t nfft,
+                   float sec_since_slot_start,
+                   const slot_info_t *info, void *ctx);
+    void (*on_slot_end)(const slot_info_t *info, void *ctx);
+    /* End-of-iteration hook. Fires after rx processing and slot-end handling.
+     * The caller may perform a blocking TX here; on return, the worker loops
+     * back around and the stale audio accumulated during TX will be drained
+     * at the next slot boundary. */
+    void (*on_tick)(const slot_info_t *info,
+                    bool new_slot,
+                    float sec_since_slot_start,
+                    void *ctx);
+    void *ctx;
+} audio_worker_cb_t;
+
+/* Create + configure the worker. Does NOT start the thread. */
+audio_worker_t *audio_worker_create(int audio_sample_rate,
+                                    int decim_ratio,
+                                    ftx_protocol_t proto,
+                                    int32_t filter_low_hz,
+                                    int32_t filter_high_hz,
+                                    const audio_worker_cb_t *cb);
+
+/* Start the decode thread. */
+int audio_worker_start(audio_worker_t *w);
+
+/* Cooperative shutdown: set stop flag, signal cv, join. No pthread_cancel. */
+void audio_worker_stop(audio_worker_t *w);
+
+/* Release all resources. Calls audio_worker_stop() first if still running. */
+void audio_worker_destroy(audio_worker_t *w);
+
+/* Push audio samples from the radio audio callback (any thread). */
+void audio_worker_feed(audio_worker_t *w, unsigned int n, float complex *samples);
+
+/* Waterfall FFT size chosen from filter bandwidth at create time. */
+uint16_t audio_worker_nfft(const audio_worker_t *w);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ft8/auto_dnf.c
+++ b/src/ft8/auto_dnf.c
@@ -1,0 +1,519 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 auto DNF (slot-begin peak notch)
+ *
+ *  Copyright (c) 2026
+ */
+
+#include "auto_dnf.h"
+#include "ft8_log.h"
+
+#include <math.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <ft8lib/constants.h>
+
+#include "../cfg/cfg.h"
+#include "../cfg/subjects.h"
+#include "../scheduler.h"
+
+#define FLOOR_SAMPLES_MAX   4096
+#define FLOOR_PERCENTILE    25          /* 25th percentile of band max-pool */
+#define HALF_WIDTH_HZ       35          /* 70 Hz notch width */
+
+/* Single-instance module: the FT8 dialog can only have one auto_dnf active
+ * at a time, and scheduler_put trampolines need to address "the" instance
+ * unambiguously. */
+static auto_dnf_ctx_t *g_self = NULL;
+
+typedef struct {
+    int32_t dnf;
+    int32_t center;
+    int32_t width;
+    bool    valid;
+} dnf_state_t;
+
+struct auto_dnf_ctx_s {
+    ft8_tuning_t tuning;
+
+    /* Geometry (pixel extents of the waterfall overlay area). */
+    lv_obj_t  *line_l;
+    lv_obj_t  *line_r;
+    lv_obj_t  *label;
+    lv_coord_t overlay_x;
+    lv_coord_t overlay_y;
+    lv_coord_t overlay_h;
+    lv_coord_t overlay_w_px;
+    int32_t    filter_low_hz;
+    int32_t    filter_high_hz;
+
+    /* Entry snapshot - restored on dialog close. */
+    dnf_state_t entry;
+
+    /* Override state. */
+    bool        override_active;
+    uint64_t    active_slot_start;
+    uint64_t    clear_scheduled_slot_start;
+
+    /* Per-slot scan state. */
+    uint64_t    slot_seen;                 /* last slot we reset max-pool for */
+    bool        applied_this_slot;
+    float      *maxpool;                   /* [nfft] */
+    uint16_t    maxpool_nfft;
+
+    /* Floor history (low-percentile rolling mean). */
+    double      floor_sum;
+    uint32_t    floor_count;
+    Observer   *obs_band;
+    Observer   *obs_att;
+    Observer   *obs_pre;
+
+    /* Scratch for percentile sort, sized once in create(). */
+    float       floor_samples[FLOOR_SAMPLES_MAX];
+};
+
+/* ---------- overlay ---------------------------------------------------- */
+
+static int32_t clip_i32(int32_t v, int32_t lo, int32_t hi) {
+    if (v < lo) return lo;
+    if (v > hi) return hi;
+    return v;
+}
+
+static void overlay_hide(auto_dnf_ctx_t *ctx) {
+    if (ctx->line_l) lv_obj_add_flag(ctx->line_l, LV_OBJ_FLAG_HIDDEN);
+    if (ctx->line_r) lv_obj_add_flag(ctx->line_r, LV_OBJ_FLAG_HIDDEN);
+    if (ctx->label)  lv_obj_add_flag(ctx->label,  LV_OBJ_FLAG_HIDDEN);
+}
+
+static void overlay_show(auto_dnf_ctx_t *ctx,
+                         uint16_t center_hz,
+                         uint16_t half_width_hz,
+                         float delta_db,
+                         bool dnf_applied) {
+    if (!ctx->line_l || !ctx->line_r || !ctx->label) return;
+
+    int32_t span = ctx->filter_high_hz - ctx->filter_low_hz;
+    if (span <= 0) return;
+
+    int32_t left_hz  = (int32_t)center_hz - (int32_t)half_width_hz;
+    int32_t right_hz = (int32_t)center_hz + (int32_t)half_width_hz;
+    left_hz  = clip_i32(left_hz,  ctx->filter_low_hz, ctx->filter_high_hz);
+    right_hz = clip_i32(right_hz, ctx->filter_low_hz, ctx->filter_high_hz);
+
+    int32_t x_l = (int32_t)((int64_t)(left_hz  - ctx->filter_low_hz) * ctx->overlay_w_px / span);
+    int32_t x_r = (int32_t)((int64_t)(right_hz - ctx->filter_low_hz) * ctx->overlay_w_px / span);
+    x_l = clip_i32(x_l, 0, ctx->overlay_w_px - 1);
+    x_r = clip_i32(x_r, 0, ctx->overlay_w_px - 1);
+
+    lv_obj_set_pos(ctx->line_l, (lv_coord_t)(ctx->overlay_x + x_l), ctx->overlay_y);
+    lv_obj_set_pos(ctx->line_r, (lv_coord_t)(ctx->overlay_x + x_r), ctx->overlay_y);
+
+    char buf[32];
+    snprintf(buf, sizeof(buf), "+ %.0f dB", (double)delta_db);
+    lv_label_set_text(ctx->label, buf);
+    lv_obj_set_pos(ctx->label,
+                   (lv_coord_t)(ctx->overlay_x + (x_l < x_r ? x_l : x_r)),
+                   ctx->overlay_y);
+    lv_obj_set_style_text_color(
+        ctx->label,
+        dnf_applied ? lv_color_hex(0xFF0000) : lv_color_hex(0x0066FF),
+        LV_PART_MAIN);
+
+    lv_obj_clear_flag(ctx->line_l, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(ctx->line_r, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(ctx->label,  LV_OBJ_FLAG_HIDDEN);
+}
+
+/* ---------- scheduler trampolines (UI thread) ------------------------- */
+
+typedef struct {
+    uint16_t center_hz;
+    uint16_t half_width_hz;
+    float    delta_db;
+    uint64_t slot_start;
+    bool     apply_dnf;
+} apply_msg_t;
+
+typedef struct {
+    uint64_t slot_start;
+} clear_msg_t;
+
+static void do_restore_now(auto_dnf_ctx_t *ctx);
+
+static void apply_cb(void *arg) {
+    auto_dnf_ctx_t *ctx = g_self;
+    if (!ctx) return;
+    const apply_msg_t *m = (const apply_msg_t *)arg;
+
+    /* Protect against stale scheduler deliveries crossing slot boundaries. */
+    struct timespec ts_now;
+    clock_gettime(CLOCK_REALTIME, &ts_now);
+    int proto = subject_get_int(cfg.ft8_protocol.val);
+    uint64_t slot_ns = (proto == FTX_PROTOCOL_FT4) ? 7500000000ULL : 15000000000ULL;
+    uint64_t epoch_ns = (uint64_t)ts_now.tv_sec * 1000000000ULL + (uint64_t)ts_now.tv_nsec;
+    uint64_t cur_slot_start = epoch_ns / slot_ns;
+    if (m->slot_start != cur_slot_start) return;
+
+    /* Always update overlay so the user can see the detection even when we
+     * don't apply the notch. */
+    overlay_show(ctx, m->center_hz, m->half_width_hz, m->delta_db, false);
+
+    if (!subject_get_int(cfg.ft8_auto_dnf.val)) return;
+    if (subject_get_int(cfg.dnf_auto.val))      return;
+    if (!m->apply_dnf)                          return;
+
+    if (!ctx->override_active && !ctx->entry.valid) {
+        /* entry snapshot not taken (create() without snapshot) - fall back
+         * to current state so we can still restore later. */
+        ctx->entry.dnf    = subject_get_int(cfg.dnf.val);
+        ctx->entry.center = subject_get_int(cfg.dnf_center.val);
+        ctx->entry.width  = subject_get_int(cfg.dnf_width.val);
+        ctx->entry.valid  = true;
+    }
+    ctx->override_active = true;
+    ctx->active_slot_start = m->slot_start;
+
+    subject_set_int(cfg.dnf.val,        true);
+    subject_set_int(cfg.dnf_center.val, m->center_hz);
+    subject_set_int(cfg.dnf_width.val,  m->half_width_hz);
+
+    /* Log only actual applies. */
+    time_t slot_start_wall = (time_t)(ts_now.tv_sec - (int)(ts_now.tv_sec % (slot_ns / 1000000000ULL)));
+    ft8_log_dnf(slot_start_wall, m->center_hz, m->delta_db);
+
+    overlay_show(ctx, m->center_hz, m->half_width_hz, m->delta_db, true);
+}
+
+static void clear_cb(void *arg) {
+    auto_dnf_ctx_t *ctx = g_self;
+    if (!ctx || !ctx->override_active) return;
+    const clear_msg_t *m = (const clear_msg_t *)arg;
+    if (m && (m->slot_start != 0) && (ctx->active_slot_start != m->slot_start)) {
+        /* Old-slot clear ran after new-slot apply - ignore. */
+        return;
+    }
+    do_restore_now(ctx);
+}
+
+static void do_restore_now(auto_dnf_ctx_t *ctx) {
+    if (ctx->override_active && ctx->entry.valid) {
+        int cur_dnf    = subject_get_int(cfg.dnf.val);
+        int cur_center = subject_get_int(cfg.dnf_center.val);
+        int cur_width  = subject_get_int(cfg.dnf_width.val);
+        if (cur_dnf    != ctx->entry.dnf)    subject_set_int(cfg.dnf.val,        ctx->entry.dnf);
+        if (cur_center != ctx->entry.center) subject_set_int(cfg.dnf_center.val, ctx->entry.center);
+        if (cur_width  != ctx->entry.width)  subject_set_int(cfg.dnf_width.val,  ctx->entry.width);
+    }
+    ctx->override_active = false;
+    ctx->active_slot_start = 0;
+    overlay_hide(ctx);
+}
+
+/* ---------- floor observer callback ----------------------------------- */
+
+static void floor_history_clear_cb(Subject *subj, void *user) {
+    (void)subj;
+    auto_dnf_ctx_t *ctx = (auto_dnf_ctx_t *)user;
+    if (!ctx) return;
+    ctx->floor_sum   = 0.0;
+    ctx->floor_count = 0;
+}
+
+/* ---------- peak detector --------------------------------------------- */
+
+static int float_asc(const void *a, const void *b) {
+    float x = *(const float *)a;
+    float y = *(const float *)b;
+    return (x < y) ? -1 : (x > y);
+}
+
+static float local_weighted(const float *maxpool, uint32_t i,
+                            uint32_t low_bin, uint32_t high_bin) {
+    /* Center-weighted kernel [1,2,3,2,1]/9 over bins (i-2..i+2), skipping
+     * out-of-range bins. */
+    static const float kw[5] = { 1.0f/9.0f, 2.0f/9.0f, 3.0f/9.0f, 2.0f/9.0f, 1.0f/9.0f };
+    float sum = 0.0f;
+    float wsum = 0.0f;
+    for (int k = -2; k <= 2; k++) {
+        int32_t bin = (int32_t)i + k;
+        if (bin < (int32_t)low_bin || bin >= (int32_t)high_bin) continue;
+        float v = maxpool[bin];
+        if (!isfinite(v) || v < -300.0f || v > 300.0f) continue;
+        sum  += v * kw[k + 2];
+        wsum += kw[k + 2];
+    }
+    return (wsum > 0.0f) ? (sum / wsum) : -1e9f;
+}
+
+static void run_peak_detection(auto_dnf_ctx_t *ctx,
+                               uint32_t low_bin, uint32_t high_bin,
+                               uint16_t nfft, int32_t sample_rate,
+                               uint64_t slot_start) {
+    /* Build percentile sample from maxpool; skip sentinel/bogus values. */
+    int cnt = 0;
+    for (uint32_t i = low_bin + 2; (i + 2) < high_bin && cnt < FLOOR_SAMPLES_MAX; i++) {
+        float v = ctx->maxpool[i];
+        if (!isfinite(v) || v < -300.0f || v > 300.0f) continue;
+        ctx->floor_samples[cnt++] = v;
+    }
+
+    float floor_db = (ctx->floor_count > 0)
+                     ? (float)(ctx->floor_sum / (double)ctx->floor_count)
+                     : -1.0e9f;
+    if (cnt > 0) {
+        qsort(ctx->floor_samples, (size_t)cnt, sizeof(float), float_asc);
+        int idx = (cnt * FLOOR_PERCENTILE) / 100;
+        if (idx >= cnt) idx = cnt - 1;
+        float p25 = ctx->floor_samples[idx];
+        if (isfinite(p25) && p25 >= -300.0f && p25 <= 300.0f) {
+            ctx->floor_sum += (double)p25;
+            ctx->floor_count++;
+            floor_db = (float)(ctx->floor_sum / (double)ctx->floor_count);
+        }
+    }
+
+    float peak_db = -1.0e9f;
+    int   peak_bin = -1;
+    for (uint32_t i = low_bin + 2; (i + 2) < high_bin; i++) {
+        float v = local_weighted(ctx->maxpool, i, low_bin, high_bin);
+        if (!isfinite(v) || v < -300.0f || v > 300.0f) continue;
+        if (v > peak_db) { peak_db = v; peak_bin = (int)i; }
+    }
+
+    if (peak_bin < 0) return;
+
+    float delta_db = (floor_db > -300.0f && peak_db > -300.0f) ? (peak_db - floor_db) : 0.0f;
+    if (!isfinite(delta_db) || delta_db < 0.0f) delta_db = 0.0f;
+    if (delta_db > 200.0f) delta_db = 200.0f;
+
+    const float hz_per_bin = (float)sample_rate / (float)nfft;
+    float   bin_hz = ((float)(peak_bin - (int)(nfft / 2))) * hz_per_bin;
+    /* +7Hz: Costas sync tone offset to actual transmit frequency. */
+    uint16_t center_hz = (uint16_t)lroundf(fabsf(bin_hz)) + 7;
+    bool apply_dnf = (delta_db >= ctx->tuning.min_delta_db);
+
+    apply_msg_t m = {
+        .center_hz     = center_hz,
+        .half_width_hz = (uint16_t)HALF_WIDTH_HZ,
+        .delta_db      = delta_db,
+        .slot_start    = slot_start,
+        .apply_dnf     = apply_dnf,
+    };
+    scheduler_put(apply_cb, &m, sizeof(m));
+    if (apply_dnf) ctx->applied_this_slot = true;
+}
+
+/* ---------- public: worker PSD hook ----------------------------------- */
+
+void auto_dnf_on_psd(auto_dnf_ctx_t *ctx,
+                     const float *psd, uint16_t nfft,
+                     int32_t sample_rate,
+                     int32_t filter_low_hz,
+                     int32_t filter_high_hz,
+                     struct timespec frame_ts,
+                     bool is_our_tx_slot) {
+    if (!ctx || !psd || nfft == 0) return;
+    if (!subject_get_int(cfg.ft8_auto_dnf.val)) return;
+
+    /* Lazy-size the max-pool buffer when nfft first becomes known. */
+    if (ctx->maxpool_nfft != nfft) {
+        free(ctx->maxpool);
+        ctx->maxpool = (float *)malloc((size_t)nfft * sizeof(float));
+        ctx->maxpool_nfft = nfft;
+        if (!ctx->maxpool) { ctx->maxpool_nfft = 0; return; }
+        for (uint32_t i = 0; i < nfft; i++) ctx->maxpool[i] = -1e9f;
+    }
+
+    int32_t span = filter_high_hz - filter_low_hz;
+    if (span <= 0) return;
+
+    uint32_t low_bin  = nfft / 2 + (uint32_t)((int32_t)nfft * filter_low_hz  / sample_rate);
+    uint32_t high_bin = nfft / 2 + (uint32_t)((int32_t)nfft * filter_high_hz / sample_rate);
+    if (high_bin > nfft) high_bin = nfft;
+    if (high_bin <= low_bin + 8) return;
+
+    /* Slot id from PSD frame timestamp (not current wall clock).
+     * This aligns DNF scan windows with the actual audio, removing
+     * the FFT pipeline latency mismatch.
+     *
+     * The clear path below uses wall clock separately — the notch must
+     * be removed BEFORE the real slot boundary, not delayed by the
+     * pipeline latency that the PSD timestamp carries. */
+    int proto = subject_get_int(cfg.ft8_protocol.val);
+    uint64_t slot_ns = (proto == FTX_PROTOCOL_FT4) ? 7500000000ULL : 15000000000ULL;
+    uint64_t epoch_ns = (uint64_t)frame_ts.tv_sec * 1000000000ULL + (uint64_t)frame_ts.tv_nsec;
+    uint64_t slot_start = epoch_ns / slot_ns;
+    float sec_since_slot_start = (float)(epoch_ns - slot_start * slot_ns) / 1.0e9f;
+
+    float slot_period = (proto == FTX_PROTOCOL_FT4) ? FT4_SLOT_TIME : FT8_SLOT_TIME;
+
+    if (slot_start != ctx->slot_seen) {
+        ctx->slot_seen                    = slot_start;
+        ctx->applied_this_slot            = false;
+        ctx->clear_scheduled_slot_start   = 0;
+        for (uint32_t i = low_bin; i < high_bin && i < nfft; i++) {
+            ctx->maxpool[i] = -1e9f;
+        }
+    }
+
+    /* Pre-expire the active notch near slot end so the next scan sees
+     * un-notched PSD. Uses wall clock (not PSD frame_ts) so the clear
+     * fires before the real slot boundary, not delayed by pipeline latency. */
+    {
+        struct timespec ts_wall;
+        clock_gettime(CLOCK_REALTIME, &ts_wall);
+        uint64_t wall_ns = (uint64_t)ts_wall.tv_sec * 1000000000ULL + (uint64_t)ts_wall.tv_nsec;
+        uint64_t wall_slot_start = wall_ns / slot_ns;
+        float wall_sec = (float)(wall_ns - wall_slot_start * slot_ns) / 1.0e9f;
+
+        if (ctx->override_active && ctx->active_slot_start != 0 &&
+            ctx->clear_scheduled_slot_start != wall_slot_start &&
+            wall_sec > (slot_period - ctx->tuning.clear_time_sec)) {
+            clear_msg_t m = { .slot_start = ctx->active_slot_start };
+            scheduler_put(clear_cb, &m, sizeof(m));
+            ctx->clear_scheduled_slot_start = wall_slot_start;
+        }
+    }
+
+    if (is_our_tx_slot || ctx->applied_this_slot) return;
+
+    if (sec_since_slot_start >= ctx->tuning.scan_start_sec &&
+        sec_since_slot_start <  ctx->tuning.scan_end_sec) {
+        /* Accumulate max-pool across the scan window. */
+        for (uint32_t i = low_bin + 2; (i + 2) < high_bin; i++) {
+            if (psd[i] > ctx->maxpool[i]) ctx->maxpool[i] = psd[i];
+        }
+        return;
+    }
+
+    if (sec_since_slot_start >= ctx->tuning.scan_end_sec) {
+        run_peak_detection(ctx, low_bin, high_bin, nfft, sample_rate, slot_start);
+    }
+}
+
+void auto_dnf_clear_for_tx(auto_dnf_ctx_t *ctx) {
+    if (!ctx || !ctx->override_active) return;
+    clear_msg_t m = { .slot_start = ctx->active_slot_start };
+    scheduler_put(clear_cb, &m, sizeof(m));
+}
+
+/* ---------- entry snapshot / restore ---------------------------------- */
+
+void auto_dnf_snapshot_entry(auto_dnf_ctx_t *ctx) {
+    if (!ctx) return;
+    ctx->entry.dnf    = subject_get_int(cfg.dnf.val);
+    ctx->entry.center = subject_get_int(cfg.dnf_center.val);
+    ctx->entry.width  = subject_get_int(cfg.dnf_width.val);
+    ctx->entry.valid  = true;
+}
+
+void auto_dnf_restore_entry(auto_dnf_ctx_t *ctx) {
+    if (!ctx || !ctx->entry.valid) return;
+
+    int cur_dnf    = subject_get_int(cfg.dnf.val);
+    int cur_center = subject_get_int(cfg.dnf_center.val);
+    int cur_width  = subject_get_int(cfg.dnf_width.val);
+    if (cur_dnf    != ctx->entry.dnf)    subject_set_int(cfg.dnf.val,        ctx->entry.dnf);
+    if (cur_center != ctx->entry.center) subject_set_int(cfg.dnf_center.val, ctx->entry.center);
+    if (cur_width  != ctx->entry.width)  subject_set_int(cfg.dnf_width.val,  ctx->entry.width);
+
+    ctx->override_active   = false;
+    ctx->active_slot_start = 0;
+    overlay_hide(ctx);
+}
+
+/* ---------- overlay build --------------------------------------------- */
+
+void auto_dnf_build_overlay(auto_dnf_ctx_t *ctx,
+                            lv_obj_t *parent,
+                            lv_coord_t overlay_x,
+                            lv_coord_t overlay_y,
+                            lv_coord_t overlay_h,
+                            lv_coord_t overlay_w_px,
+                            int32_t filter_low_hz,
+                            int32_t filter_high_hz) {
+    if (!ctx) return;
+    ctx->overlay_x      = overlay_x;
+    ctx->overlay_y      = overlay_y;
+    ctx->overlay_h      = overlay_h;
+    ctx->overlay_w_px   = overlay_w_px;
+    ctx->filter_low_hz  = filter_low_hz;
+    ctx->filter_high_hz = filter_high_hz;
+
+    ctx->line_l = lv_obj_create(parent);
+    lv_obj_clear_flag(ctx->line_l, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_size(ctx->line_l, 2, overlay_h);
+    lv_obj_set_style_border_width(ctx->line_l, 0, LV_PART_MAIN);
+    lv_obj_set_style_radius(ctx->line_l, 0, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(ctx->line_l, lv_color_hex(0x0066FF), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(ctx->line_l, LV_OPA_80, LV_PART_MAIN);
+    lv_obj_add_flag(ctx->line_l, LV_OBJ_FLAG_HIDDEN);
+
+    ctx->line_r = lv_obj_create(parent);
+    lv_obj_clear_flag(ctx->line_r, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_size(ctx->line_r, 2, overlay_h);
+    lv_obj_set_style_border_width(ctx->line_r, 0, LV_PART_MAIN);
+    lv_obj_set_style_radius(ctx->line_r, 0, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(ctx->line_r, lv_color_hex(0x0066FF), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(ctx->line_r, LV_OPA_80, LV_PART_MAIN);
+    lv_obj_add_flag(ctx->line_r, LV_OBJ_FLAG_HIDDEN);
+
+    ctx->label = lv_label_create(parent);
+    lv_obj_set_style_text_color(ctx->label, lv_color_hex(0x0066FF), LV_PART_MAIN);
+    lv_obj_set_style_text_opa(ctx->label,   LV_OPA_COVER,           LV_PART_MAIN);
+    lv_label_set_text(ctx->label, "");
+    lv_obj_add_flag(ctx->label, LV_OBJ_FLAG_HIDDEN);
+}
+
+/* ---------- create / destroy ------------------------------------------ */
+
+auto_dnf_ctx_t *auto_dnf_create(const ft8_tuning_t *tuning) {
+    auto_dnf_ctx_t *ctx = (auto_dnf_ctx_t *)calloc(1, sizeof(*ctx));
+    if (!ctx) return NULL;
+    if (tuning) {
+        ctx->tuning = *tuning;
+    } else {
+        ctx->tuning.scan_start_sec = FT8_AUTO_DNF_SCAN_START_SEC_DEFAULT;
+        ctx->tuning.scan_end_sec   = FT8_AUTO_DNF_SCAN_END_SEC_DEFAULT;
+        ctx->tuning.clear_time_sec = FT8_AUTO_DNF_CLEAR_TIME_SEC_DEFAULT;
+        ctx->tuning.min_delta_db   = FT8_AUTO_DNF_MIN_DELTA_DB_DEFAULT;
+    }
+
+    ctx->obs_band = subject_add_observer(cfg.band_id.val,  floor_history_clear_cb, ctx);
+    ctx->obs_att  = subject_add_observer(cfg_cur.att,      floor_history_clear_cb, ctx);
+    ctx->obs_pre  = subject_add_observer(cfg_cur.pre,      floor_history_clear_cb, ctx);
+
+    g_self = ctx;
+    return ctx;
+}
+
+void auto_dnf_destroy(auto_dnf_ctx_t *ctx) {
+    if (!ctx) return;
+
+    /* Deleting observers in reverse order of creation. */
+    if (ctx->obs_pre)  { observer_del(ctx->obs_pre);  ctx->obs_pre  = NULL; }
+    if (ctx->obs_att)  { observer_del(ctx->obs_att);  ctx->obs_att  = NULL; }
+    if (ctx->obs_band) { observer_del(ctx->obs_band); ctx->obs_band = NULL; }
+
+    /* Always restore in case destroy is called without an explicit
+     * restore_entry() call. */
+    auto_dnf_restore_entry(ctx);
+
+    if (ctx->maxpool) { free(ctx->maxpool); ctx->maxpool = NULL; }
+
+    /* LVGL overlay objects are parented to the dialog and will be deleted
+     * with it. Just forget the pointers. */
+    ctx->line_l = NULL;
+    ctx->line_r = NULL;
+    ctx->label  = NULL;
+
+    if (g_self == ctx) g_self = NULL;
+    free(ctx);
+}

--- a/src/ft8/auto_dnf.h
+++ b/src/ft8/auto_dnf.h
@@ -1,0 +1,80 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 auto DNF (slot-begin peak notch)
+ *
+ *  Copyright (c) 2026
+ */
+
+/*
+ *  Auto DNF (Do-Not-Force) watches the waterfall PSD during the first 0.25..0.75s
+ *  of each slot, detects a dominant interferer via time-dimension max-pool + a
+ *  25th-percentile floor estimate, and if the peak stands out by more than
+ *  min_delta_db, engages the radio's manual DNF notch at the peak center.
+ *
+ *  All state is owned by auto_dnf_ctx_t. create/destroy own the entry
+ *  snapshot and the band/att/pre observers; restore_entry() is called on
+ *  dialog close even if we crash during teardown.
+ *
+ *  Threading:
+ *    - auto_dnf_on_psd() runs on the worker thread (no LVGL calls).
+ *    - UI apply / clear actually happen on the scheduler (UI thread) via
+ *      scheduler_put() trampolines owned by this module.
+ *    - auto_dnf_snapshot_entry / restore_entry / build_overlay / destroy run
+ *      on the UI thread from the dialog lifecycle.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <time.h>
+
+#include "lvgl/lvgl.h"
+
+#include "params.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct auto_dnf_ctx_s auto_dnf_ctx_t;
+
+auto_dnf_ctx_t *auto_dnf_create(const ft8_tuning_t *tuning);
+void            auto_dnf_destroy(auto_dnf_ctx_t *ctx);
+
+/* Overlay UI (blue peak lines + delta_db label drawn over the waterfall). */
+void auto_dnf_build_overlay(auto_dnf_ctx_t *ctx,
+                            lv_obj_t *parent,
+                            lv_coord_t overlay_x,
+                            lv_coord_t overlay_y,
+                            lv_coord_t overlay_h,
+                            lv_coord_t overlay_w_px,
+                            int32_t filter_low_hz,
+                            int32_t filter_high_hz);
+
+/* User opened the FT8 dialog - remember current DNF settings so we can
+ * restore them on close. */
+void auto_dnf_snapshot_entry(auto_dnf_ctx_t *ctx);
+
+/* Restore the DNF subjects to the entry snapshot. Safe to call multiple
+ * times; second+ calls are no-ops. */
+void auto_dnf_restore_entry(auto_dnf_ctx_t *ctx);
+
+/* Worker-thread hook per waterfall PSD frame.
+ * frame_ts is the wall-clock timestamp of the audio this PSD represents
+ * (NOT the current wall clock), used for slot-aligned scan/clear timing. */
+void auto_dnf_on_psd(auto_dnf_ctx_t *ctx,
+                     const float *psd, uint16_t nfft,
+                     int32_t sample_rate,
+                     int32_t filter_low_hz,
+                     int32_t filter_high_hz,
+                     struct timespec frame_ts,
+                     bool is_our_tx_slot);
+
+/* TX just started - clear any active notch so it does not affect our TX. */
+void auto_dnf_clear_for_tx(auto_dnf_ctx_t *ctx);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ft8/auto_sel.cpp
+++ b/src/ft8/auto_sel.cpp
@@ -1,0 +1,381 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 auto-select (unseen-CQ picker)
+ *
+ *  Copyright (c) 2026
+ */
+
+#include "auto_sel.h"
+
+/* subjects.h and cfg.h already gate their C++/C contents internally; do
+ * NOT wrap them in extern "C" or their own STL includes get C linkage. */
+#include "../cfg/subjects.h"
+#include "../cfg/cfg.h"
+
+#include <ft8lib/constants.h>
+
+extern "C" {
+#include "../qso_log.h"
+}
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr size_t   MAX_UNSEEN                   = 100;
+constexpr size_t   CYCLE_BL_SIZE                = 8;
+constexpr uint8_t  CYCLE_BL_CLEAR_MISS          = 2;
+constexpr size_t   USER_BL_CALL_MAX_LEN         = 15;   /* matches 16-1 in old code */
+constexpr const char *USER_BL_PATH              = "/mnt/autosel_blacklist.txt";
+
+struct UnseenEntry {
+    ftx_msg_meta_t meta;
+    int            dist;
+    int            snr;
+};
+
+struct CycleEntry {
+    char    call[16];
+    uint8_t miss_cycles;
+    bool    seen_this_cycle;
+};
+
+std::mutex                                  g_mutex;
+std::deque<UnseenEntry>                     g_unseen;
+std::array<CycleEntry, CYCLE_BL_SIZE>       g_cycle_bl{};
+std::vector<std::string>                    g_user_bl;
+
+/* ---- helpers (hold g_mutex while calling these) ----------------------- */
+
+void trim_in_place(std::string &s) {
+    while (!s.empty() && std::isspace(static_cast<unsigned char>(s.front()))) {
+        s.erase(s.begin());
+    }
+    while (!s.empty() && std::isspace(static_cast<unsigned char>(s.back()))) {
+        s.pop_back();
+    }
+}
+
+void normalize_call(const char *in, std::string &out) {
+    out.clear();
+    if (!in) return;
+    out.assign(in);
+
+    /* Strip UTF-8 BOM if present. */
+    if (out.size() >= 3 &&
+        static_cast<unsigned char>(out[0]) == 0xEF &&
+        static_cast<unsigned char>(out[1]) == 0xBB &&
+        static_cast<unsigned char>(out[2]) == 0xBF) {
+        out.erase(0, 3);
+    }
+    trim_in_place(out);
+
+    for (auto &c : out) {
+        c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+    }
+    if (out.size() > USER_BL_CALL_MAX_LEN) out.resize(USER_BL_CALL_MAX_LEN);
+}
+
+bool user_blacklisted_norm(const std::string &norm) {
+    if (norm.empty()) return false;
+    for (const auto &s : g_user_bl) {
+        if (s == norm) return true;
+    }
+    return false;
+}
+
+bool cycle_blacklisted_norm(const std::string &norm) {
+    if (norm.empty()) return false;
+    for (const auto &e : g_cycle_bl) {
+        if (e.call[0] != '\0' && (norm == e.call)) return true;
+    }
+    return false;
+}
+
+bool any_blacklisted_norm(const std::string &norm) {
+    return user_blacklisted_norm(norm) || cycle_blacklisted_norm(norm);
+}
+
+void save_user_bl_locked(bool use_crlf) {
+    const char *eol      = use_crlf ? "\r\n" : "\n";
+    std::string tmp_path = std::string(USER_BL_PATH) + ".tmp";
+    FILE *fp = std::fopen(tmp_path.c_str(), "wb");
+    if (!fp) return;
+    for (const auto &s : g_user_bl) {
+        if (s.empty()) continue;
+        std::fputs(s.c_str(), fp);
+        std::fputs(eol, fp);
+    }
+    std::fflush(fp);
+    std::fclose(fp);
+    if (std::rename(tmp_path.c_str(), USER_BL_PATH) != 0) {
+        std::remove(tmp_path.c_str());
+    }
+}
+
+} /* namespace */
+
+/* -------------------- public C API ------------------------------------- */
+
+extern "C" void autosel_init(void) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_unseen.clear();
+    for (auto &e : g_cycle_bl) {
+        e.call[0]          = '\0';
+        e.miss_cycles      = 0;
+        e.seen_this_cycle  = false;
+    }
+    g_user_bl.clear();
+}
+
+extern "C" void autosel_deinit(void) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_unseen.clear();
+    for (auto &e : g_cycle_bl) {
+        e.call[0]          = '\0';
+        e.miss_cycles      = 0;
+        e.seen_this_cycle  = false;
+    }
+    g_user_bl.clear();
+}
+
+extern "C" void autosel_user_blacklist_load(void) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_user_bl.clear();
+
+    bool dirty    = false;
+    bool use_crlf = false;
+
+    FILE *fp = std::fopen(USER_BL_PATH, "rb");
+    if (!fp) {
+        if (errno == ENOENT) {
+            FILE *nfp = std::fopen(USER_BL_PATH, "wb");
+            if (nfp) std::fclose(nfp);
+        }
+        return;
+    }
+
+    char line[128];
+    while (std::fgets(line, sizeof(line), fp)) {
+        if (std::strchr(line, '\r')) use_crlf = true;
+
+        std::string orig(line);
+        trim_in_place(orig);
+
+        std::string call;
+        normalize_call(line, call);
+        if (call.empty())            continue;
+        if (call[0] == '#' || call[0] == ';') continue;
+
+        if (!(orig.empty() || orig[0] == '#' || orig[0] == ';')) {
+            if (orig != call) dirty = true;
+        }
+
+        bool exists = false;
+        for (const auto &s : g_user_bl) {
+            if (s == call) { exists = true; break; }
+        }
+        if (exists) {
+            dirty = true;
+            continue;
+        }
+        g_user_bl.push_back(call);
+    }
+    std::fclose(fp);
+
+    if (dirty) save_user_bl_locked(use_crlf);
+}
+
+extern "C" void autosel_add_candidate(const ftx_msg_meta_t *meta, int dist, int snr) {
+    if (!meta) return;
+
+    /* Already worked (per qso_log)? skip. These calls take their own
+     * qso_log mutex internally so we run them outside our lock. */
+    qso_log_search_worked_t worked = qso_log_search_worked(
+        meta->call_de,
+        subject_get_int(cfg.ft8_protocol.val) == FTX_PROTOCOL_FT8 ? MODE_FT8 : MODE_FT4,
+        qso_log_freq_to_band(subject_get_int(cfg_cur.fg_freq)));
+    if (worked != SEARCH_WORKED_NO) return;
+
+    std::string norm;
+    normalize_call(meta->call_de, norm);
+
+    std::lock_guard<std::mutex> lock(g_mutex);
+    if (norm.empty() || any_blacklisted_norm(norm)) return;
+    for (const auto &u : g_unseen) {
+        if (std::strcmp(u.meta.call_de, meta->call_de) == 0) return;
+    }
+    if (g_unseen.size() >= MAX_UNSEEN) return;
+
+    UnseenEntry e;
+    e.meta = *meta;
+    e.dist = dist;
+    e.snr  = snr;
+    g_unseen.push_back(e);
+}
+
+extern "C" void autosel_clear_unseen(void) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_unseen.clear();
+}
+
+extern "C" bool autosel_pick(auto_sel_mode_t mode, autosel_candidate_t *out) {
+    if (!out || mode == AUTO_SEL_OFF) return false;
+
+    std::lock_guard<std::mutex> lock(g_mutex);
+
+    /* Purge blacklisted entries first; they may have been added before the
+     * blacklist was loaded/updated. */
+    g_unseen.erase(
+        std::remove_if(g_unseen.begin(), g_unseen.end(), [](const UnseenEntry &u) {
+            std::string norm;
+            normalize_call(u.meta.call_de, norm);
+            return any_blacklisted_norm(norm);
+        }),
+        g_unseen.end());
+
+    if (g_unseen.empty()) return false;
+
+    auto it_best = g_unseen.end();
+
+    if (mode == AUTO_SEL_FIRST) {
+        it_best = g_unseen.begin();
+    } else if (mode == AUTO_SEL_NEW_GRID) {
+        qso_log_mode_t qlog_mode = subject_get_int(cfg.ft8_protocol.val) == FTX_PROTOCOL_FT8 ? MODE_FT8 : MODE_FT4;
+        qso_log_band_t qlog_band = qso_log_freq_to_band(subject_get_int(cfg_cur.fg_freq));
+        for (auto it = g_unseen.begin(); it != g_unseen.end(); ++it) {
+            if (it->meta.grid[0] == '\0') continue;
+            if (!qso_log_search_worked_grid(it->meta.grid, qlog_mode, qlog_band)) {
+                it_best = it;
+                break;
+            }
+        }
+        if (it_best == g_unseen.end()) it_best = g_unseen.begin();
+    } else if (mode == AUTO_SEL_FARTHEST) {
+        int best_dist = 0;
+        for (auto it = g_unseen.begin(); it != g_unseen.end(); ++it) {
+            if (it->dist > best_dist) {
+                best_dist = it->dist;
+                it_best   = it;
+            }
+        }
+        if (it_best == g_unseen.end()) it_best = g_unseen.begin();
+    } else { /* AUTO_SEL_HIGHEST_SNR (and any other non-OFF value) */
+        it_best = g_unseen.begin();
+        for (auto it = std::next(g_unseen.begin()); it != g_unseen.end(); ++it) {
+            if (it->snr > it_best->snr) it_best = it;
+        }
+    }
+
+    if (it_best == g_unseen.end()) return false;
+
+    out->meta = it_best->meta;
+    out->dist = it_best->dist;
+    out->snr  = it_best->snr;
+    g_unseen.erase(it_best);
+    return true;
+}
+
+extern "C" void autosel_blacklist_add(const char *call) {
+    if (!call || call[0] == '\0') return;
+    std::string norm;
+    normalize_call(call, norm);
+    if (norm.empty()) return;
+
+    std::lock_guard<std::mutex> lock(g_mutex);
+
+    /* Refresh existing */
+    for (auto &e : g_cycle_bl) {
+        if (e.call[0] != '\0' && norm == e.call) {
+            e.miss_cycles     = 0;
+            e.seen_this_cycle = true;
+            return;
+        }
+    }
+    /* Free slot */
+    for (auto &e : g_cycle_bl) {
+        if (e.call[0] == '\0') {
+            std::snprintf(e.call, sizeof(e.call), "%s", norm.c_str());
+            e.miss_cycles     = 0;
+            e.seen_this_cycle = true;
+            return;
+        }
+    }
+    /* Evict entry with the largest miss count. */
+    size_t worst = 0;
+    for (size_t i = 1; i < g_cycle_bl.size(); i++) {
+        if (g_cycle_bl[i].miss_cycles > g_cycle_bl[worst].miss_cycles) worst = i;
+    }
+    std::snprintf(g_cycle_bl[worst].call, sizeof(g_cycle_bl[worst].call), "%s", norm.c_str());
+    g_cycle_bl[worst].miss_cycles     = 0;
+    g_cycle_bl[worst].seen_this_cycle = true;
+}
+
+extern "C" void autosel_blacklist_mark_seen(const char *call) {
+    if (!call || call[0] == '\0') return;
+    std::string norm;
+    normalize_call(call, norm);
+    if (norm.empty()) return;
+
+    std::lock_guard<std::mutex> lock(g_mutex);
+    for (auto &e : g_cycle_bl) {
+        if (e.call[0] != '\0' && norm == e.call) {
+            e.seen_this_cycle = true;
+            return;
+        }
+    }
+}
+
+extern "C" void autosel_blacklist_advance_cycle(void) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    for (auto &e : g_cycle_bl) {
+        if (e.call[0] == '\0') continue;
+        if (e.seen_this_cycle) {
+            e.miss_cycles = 0;
+        } else {
+            if (e.miss_cycles < 255) e.miss_cycles++;
+        }
+        e.seen_this_cycle = false;
+        if (e.miss_cycles >= CYCLE_BL_CLEAR_MISS) {
+            e.call[0]         = '\0';
+            e.miss_cycles     = 0;
+            e.seen_this_cycle = false;
+        }
+    }
+}
+
+extern "C" void autosel_blacklist_clear_all(void) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    for (auto &e : g_cycle_bl) {
+        e.call[0]         = '\0';
+        e.miss_cycles     = 0;
+        e.seen_this_cycle = false;
+    }
+}
+
+extern "C" bool autosel_is_user_blacklisted(const char *call) {
+    if (!call || call[0] == '\0') return false;
+    std::string norm;
+    normalize_call(call, norm);
+    std::lock_guard<std::mutex> lock(g_mutex);
+    return user_blacklisted_norm(norm);
+}
+
+extern "C" bool autosel_is_blacklisted(const char *call) {
+    if (!call || call[0] == '\0') return false;
+    std::string norm;
+    normalize_call(call, norm);
+    std::lock_guard<std::mutex> lock(g_mutex);
+    return any_blacklisted_norm(norm);
+}

--- a/src/ft8/auto_sel.h
+++ b/src/ft8/auto_sel.h
@@ -1,0 +1,75 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 auto-select (unseen-CQ picker)
+ *
+ *  Copyright (c) 2026
+ */
+
+/*
+ *  Tracks CQ callers observed during the current slot window, filters them
+ *  by the system cycle blacklist and the user's persistent blacklist, and
+ *  picks one for auto-QSO according to auto_sel_mode_t.
+ *
+ *  Backed by std::deque<UnseenEntry> (per-slot scratch), std::array<> for
+ *  the short cycle blacklist, and std::vector<std::string> for the user
+ *  blacklist. All accesses are mutex-protected so worker-thread
+ *  autosel_add_candidate() and UI-thread autosel_pick() are safe.
+ *
+ *  C-compatible API so C callers (qso_state, dialog) can use it directly.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "qso.h"   /* ftx_msg_meta_t */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    AUTO_SEL_OFF         = 0,
+    AUTO_SEL_FIRST       = 1,
+    AUTO_SEL_FARTHEST    = 2,
+    AUTO_SEL_HIGHEST_SNR = 3,
+    AUTO_SEL_NEW_GRID    = 4,
+} auto_sel_mode_t;
+
+typedef struct {
+    ftx_msg_meta_t meta;
+    int            dist;
+    int            snr;
+} autosel_candidate_t;
+
+void autosel_init(void);
+void autosel_deinit(void);
+
+/* Load / persist /mnt/autosel_blacklist.txt. */
+void autosel_user_blacklist_load(void);
+
+/* Worker thread: register a CQ caller observed in this slot. */
+void autosel_add_candidate(const ftx_msg_meta_t *meta, int dist, int snr);
+
+/* UI thread: pick a candidate per mode. Returns false if nothing suitable. */
+bool autosel_pick(auto_sel_mode_t mode, autosel_candidate_t *out);
+
+/* Drop all unseen candidates (end-of-slot hygiene). */
+void autosel_clear_unseen(void);
+
+/* System cycle blacklist. Calls normalise callsigns internally. */
+void autosel_blacklist_add(const char *call);
+void autosel_blacklist_mark_seen(const char *call);
+void autosel_blacklist_advance_cycle(void);
+void autosel_blacklist_clear_all(void);
+
+/* Blacklist checks. user_blacklisted() reads only the persistent list; 
+ * blacklisted() reads either list. */
+bool autosel_is_user_blacklisted(const char *call);
+bool autosel_is_blacklisted(const char *call);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ft8/cq_scheduler.c
+++ b/src/ft8/cq_scheduler.c
@@ -1,0 +1,113 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 CQ scheduler
+ *
+ *  Copyright (c) 2026
+ */
+
+#include "cq_scheduler.h"
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include <ft8lib/constants.h>
+#include <ft8lib/message.h>
+
+#include "../cfg/cfg.h"
+#include "../msg.h"
+#include "../params/params.h"
+
+#define MAX_TX_START_DELAY_SEC  1.5f
+
+void cq_state_reset(cq_state_t *cq) {
+    if (!cq) return;
+    cq->paused_for_qso = false;
+}
+
+void cq_make_message(const char *callsign,
+                     const char *qth,
+                     const char *cq_mod,
+                     char *out, size_t out_sz,
+                     bool omit_qth) {
+    if (!out || out_sz == 0) return;
+    if (!callsign) callsign = "";
+    if (!qth)      qth      = "";
+    if (!cq_mod)   cq_mod   = "";
+
+    if (cq_mod[0] != '\0') {
+        snprintf(out, out_sz, "CQ_%s %s", cq_mod, callsign);
+    } else {
+        snprintf(out, out_sz, "CQ %s", callsign);
+    }
+
+    if (!omit_qth) {
+        size_t len = strlen(out);
+        if (len + 6 < out_sz) {
+            snprintf(out + len, out_sz - len, " %.4s", qth);
+        }
+    }
+
+    /* Validate the message fits in a 77-bit FT8 frame.
+     * If callsign+grid is too long, ftx_message_encode will fail. */
+    ftx_message_t msg;
+    ftx_message_rc_t rc = ftx_message_encode(&msg, NULL, out);
+    if (rc != FTX_MESSAGE_RC_OK) {
+        LV_LOG_USER("CQ message too long for FT8: '%s' (rc=%d)", out, rc);
+        out[0] = '\0';
+    }
+}
+
+static bool get_time_slot_odd(ftx_protocol_t proto, float *sec_since_start) {
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME, &now);
+    float sec       = (float)(now.tv_sec % 60) + (float)now.tv_nsec / 1.0e9f;
+    float slot_time = (proto == FTX_PROTOCOL_FT4) ? FT4_SLOT_TIME : FT8_SLOT_TIME;
+    *sec_since_start = fmodf(sec, slot_time);
+    return ((int)(sec / slot_time) % 2) != 0;
+}
+
+bool cq_schedule_if_needed(cq_state_t   *cq,
+                           qso_state_t  *qso,
+                           Subject      *cq_enabled_subj,
+                           Subject      *tx_enabled_subj,
+                           bool          ftx_qso_has_current) {
+    (void)cq;
+    if (!qso) return false;
+    if (!cq_enabled_subj || !subject_get_int(cq_enabled_subj)) return false;
+    if (!tx_enabled_subj || !subject_get_int(tx_enabled_subj)) return false;
+
+    if (!qso_state_tx_msg_empty(qso)) return false;
+    if (ftx_qso_has_current)          return false;
+    if (strlen(params.callsign.x) == 0) return false;
+
+    ftx_tx_msg_t m = {0};
+    cq_make_message(params.callsign.x,
+                    params.qth.x,
+                    params.ft8_cq_modifier.x,
+                    m.msg, sizeof(m.msg),
+                    subject_get_int(cfg.ft8_omit_cq_qth.val));
+    m.repeats         = subject_get_int(cfg.ft8_max_repeats.val);
+    m.force_free_text = false;
+
+    qso_state_set_tx_msg(qso, &m);
+
+    ftx_protocol_t proto = subject_get_int(cfg.ft8_protocol.val);
+    float sec_since_start = 0.0f;
+    bool  cur_odd = get_time_slot_odd(proto, &sec_since_start);
+    bool  tx_time_slot = !cur_odd;
+    if (sec_since_start < MAX_TX_START_DELAY_SEC) {
+        tx_time_slot = !tx_time_slot;
+    }
+    qso_state_set_tx_time_slot(qso, tx_time_slot);
+
+    if (m.msg[2] == '_') {
+        msg_schedule_text_fmt("Next TX: CQ %s", m.msg + 3);
+    } else {
+        msg_schedule_text_fmt("Next TX: %s", m.msg);
+    }
+    return true;
+}

--- a/src/ft8/cq_scheduler.c
+++ b/src/ft8/cq_scheduler.c
@@ -31,8 +31,7 @@ void cq_state_reset(cq_state_t *cq) {
 void cq_make_message(const char *callsign,
                      const char *qth,
                      const char *cq_mod,
-                     char *out, size_t out_sz,
-                     bool omit_qth) {
+                     char *out, size_t out_sz) {
     if (!out || out_sz == 0) return;
     if (!callsign) callsign = "";
     if (!qth)      qth      = "";
@@ -44,11 +43,9 @@ void cq_make_message(const char *callsign,
         snprintf(out, out_sz, "CQ %s", callsign);
     }
 
-    if (!omit_qth) {
-        size_t len = strlen(out);
-        if (len + 6 < out_sz) {
-            snprintf(out + len, out_sz - len, " %.4s", qth);
-        }
+    size_t len = strlen(out);
+    if (len + 6 < out_sz) {
+        snprintf(out + len, out_sz - len, " %.4s", qth);
     }
 
     /* Validate the message fits in a 77-bit FT8 frame.
@@ -88,8 +85,7 @@ bool cq_schedule_if_needed(cq_state_t   *cq,
     cq_make_message(params.callsign.x,
                     params.qth.x,
                     params.ft8_cq_modifier.x,
-                    m.msg, sizeof(m.msg),
-                    subject_get_int(cfg.ft8_omit_cq_qth.val));
+                    m.msg, sizeof(m.msg));
     m.repeats         = subject_get_int(cfg.ft8_max_repeats.val);
     m.force_free_text = false;
 

--- a/src/ft8/cq_scheduler.h
+++ b/src/ft8/cq_scheduler.h
@@ -37,8 +37,7 @@ void cq_state_reset(cq_state_t *cq);
 void cq_make_message(const char *callsign,
                      const char *qth,
                      const char *cq_mod,
-                     char *out, size_t out_sz,
-                     bool omit_qth);
+                     char *out, size_t out_sz);
 
 /* Try to schedule a CQ TX into qso_state. Returns true if the CQ was queued
  * (tx_msg populated, tx_time_slot set). Does nothing if any precondition

--- a/src/ft8/cq_scheduler.h
+++ b/src/ft8/cq_scheduler.h
@@ -1,0 +1,55 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 CQ scheduler
+ *
+ *  Copyright (c) 2026
+ */
+
+/*
+ *  Composes the next CQ TX message and decides whether/when to queue it
+ *  for the next slot. Mirrors the legacy schedule_cq_tx_if_needed() flow
+ *  but uses qso_state instead of global variables.
+ *
+ *  State here is only the "cq_paused_for_qso" flag, which lives on the UI
+ *  thread and is toggled by the session loop.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "../cfg/subjects.h"
+#include "qso_state.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    bool paused_for_qso;
+} cq_state_t;
+
+void cq_state_reset(cq_state_t *cq);
+
+/* Build a canonical CQ message "CQ [_mod] <callsign> [<grid>]" into out. */
+void cq_make_message(const char *callsign,
+                     const char *qth,
+                     const char *cq_mod,
+                     char *out, size_t out_sz,
+                     bool omit_qth);
+
+/* Try to schedule a CQ TX into qso_state. Returns true if the CQ was queued
+ * (tx_msg populated, tx_time_slot set). Does nothing if any precondition
+ * is false (tx_enabled off, cq_enabled off, tx_msg non-empty, call in
+ * progress, or empty callsign). */
+bool cq_schedule_if_needed(cq_state_t   *cq,
+                           qso_state_t  *qso,
+                           Subject      *cq_enabled_subj,
+                           Subject      *tx_enabled_subj,
+                           bool          ftx_qso_has_current);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ft8/ft8_log.c
+++ b/src/ft8/ft8_log.c
@@ -1,0 +1,209 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 file-log module
+ *
+ *  Copyright (c) 2026
+ */
+
+#include "ft8_log.h"
+
+#include <errno.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+
+#define FT8_LOG_DIR        "/mnt/ft8_logs"
+#define FT8_LOG_LINE_MAX   512
+#define FT8_LOG_QUEUE_MAX  512
+
+typedef struct rx_line_s {
+    char              *line;
+    struct rx_line_s  *next;
+} rx_line_t;
+
+static FILE      *s_fp             = NULL;
+static rx_line_t *s_rx_lines       = NULL;
+static size_t     s_rx_lines_count = 0;
+static time_t     s_rx_slot_start  = 0;
+
+static void format_slot_ts(time_t slot_start, char *out, size_t out_size) {
+    struct tm tm_slot;
+    if ((out_size == 0) || (localtime_r(&slot_start, &tm_slot) == NULL)) {
+        if (out_size) out[0] = '\0';
+        return;
+    }
+    strftime(out, out_size, "%Y-%m-%d_%H-%M-%S", &tm_slot);
+}
+
+static void rx_lines_clear(void) {
+    rx_line_t *cur = s_rx_lines;
+    while (cur) {
+        rx_line_t *next = cur->next;
+        free(cur->line);
+        free(cur);
+        cur = next;
+    }
+    s_rx_lines       = NULL;
+    s_rx_lines_count = 0;
+    s_rx_slot_start  = 0;
+}
+
+static void ensure_open(void) {
+    if (s_fp) return;
+
+    if ((mkdir(FT8_LOG_DIR, 0755) < 0) && (errno != EEXIST)) {
+        return;
+    }
+
+    time_t    now = time(NULL);
+    struct tm tm_now;
+    if (localtime_r(&now, &tm_now) == NULL) {
+        return;
+    }
+
+    char ts[32];
+    if (strftime(ts, sizeof(ts), "%Y-%m-%d_%H-%M-%S", &tm_now) == 0) {
+        return;
+    }
+
+    char path[256];
+    snprintf(path, sizeof(path), "%s/x6100_log_%s.txt", FT8_LOG_DIR, ts);
+    s_fp = fopen(path, "a");
+}
+
+void ft8_log_init(void) {
+    /* Lazy-open on first write; init here just guarantees a clean slate. */
+    ft8_log_close();
+}
+
+void ft8_log_close(void) {
+    if (s_fp) {
+        if (s_rx_lines) {
+            ft8_log_rx_flush_slot(NULL);
+        }
+        fflush(s_fp);
+        fclose(s_fp);
+        s_fp = NULL;
+    }
+    rx_lines_clear();
+}
+
+void ft8_log_rx_collect(const slot_info_t *info, float freq_hz, int snr, const char *text) {
+    if (!info || !text) return;
+    ensure_open();
+    if (!s_fp) return;
+
+    if (s_rx_slot_start != info->slot_start) {
+        rx_lines_clear();
+        s_rx_slot_start = info->slot_start;
+    }
+
+    char slot_ts[32];
+    format_slot_ts(info->slot_start, slot_ts, sizeof(slot_ts));
+
+    uint64_t rf_hz = info->base_freq_hz + (uint64_t)llroundf(freq_hz);
+
+    char line_buf[FT8_LOG_LINE_MAX];
+    snprintf(line_buf, sizeof(line_buf),
+             "RX,%s,%llu,%d,%s",
+             slot_ts,
+             (unsigned long long)rf_hz,
+             snr,
+             text);
+
+    for (rx_line_t *cur = s_rx_lines; cur; cur = cur->next) {
+        if (strcmp(cur->line, line_buf) == 0) {
+            return; /* dedup */
+        }
+    }
+
+    if (s_rx_lines_count >= FT8_LOG_QUEUE_MAX) {
+        return;
+    }
+
+    char *dup = strdup(line_buf);
+    if (!dup) return;
+
+    rx_line_t *node = (rx_line_t *)malloc(sizeof(rx_line_t));
+    if (!node) {
+        free(dup);
+        return;
+    }
+    node->line = dup;
+    node->next = s_rx_lines;
+    s_rx_lines = node;
+    s_rx_lines_count++;
+}
+
+void ft8_log_rx_flush_slot(const slot_info_t *info) {
+    (void)info;
+    if (!s_fp || !s_rx_lines) {
+        rx_lines_clear();
+        return;
+    }
+
+    /* In-place reverse so oldest-first. The collect queue is prepended, so
+     * s_rx_lines is currently newest-first.
+     */
+    rx_line_t *rev = NULL;
+    rx_line_t *cur = s_rx_lines;
+    while (cur) {
+        rx_line_t *next = cur->next;
+        cur->next = rev;
+        rev = cur;
+        cur = next;
+    }
+    s_rx_lines = rev;
+
+    for (cur = s_rx_lines; cur; cur = cur->next) {
+        fprintf(s_fp, "%s\n", cur->line);
+    }
+    fflush(s_fp);
+    rx_lines_clear();
+}
+
+void ft8_log_tx(time_t slot_start, uint64_t base_freq_hz, uint32_t hz_offset, const char *text) {
+    if (!text) return;
+    ensure_open();
+    if (!s_fp) return;
+
+    char slot_ts[32];
+    format_slot_ts(slot_start, slot_ts, sizeof(slot_ts));
+
+    uint64_t rf_hz = base_freq_hz + (uint64_t)hz_offset;
+
+    char msg_buf[96];
+    strncpy(msg_buf, text, sizeof(msg_buf) - 1);
+    msg_buf[sizeof(msg_buf) - 1] = '\0';
+    if (strncmp(msg_buf, "CQ_", 3) == 0) {
+        msg_buf[2] = ' ';
+    }
+
+    fprintf(s_fp, "TX,%s,%llu,%s\n", slot_ts, (unsigned long long)rf_hz, msg_buf);
+    fflush(s_fp);
+}
+
+void ft8_log_qso(time_t slot_start, const char *remote_call) {
+    if (!remote_call || (remote_call[0] == '\0')) return;
+    ensure_open();
+    if (!s_fp) return;
+
+    char slot_ts[32];
+    format_slot_ts(slot_start, slot_ts, sizeof(slot_ts));
+    fprintf(s_fp, "QSO,%s,%s\n", slot_ts, remote_call);
+    fflush(s_fp);
+}
+
+void ft8_log_dnf(time_t slot_start, uint16_t center_hz, float delta_db) {
+    ensure_open();
+    if (!s_fp) return;
+
+    char slot_ts[32];
+    format_slot_ts(slot_start, slot_ts, sizeof(slot_ts));
+    fprintf(s_fp, "DNF,%s,%u,%.1f\n", slot_ts, (unsigned)center_hz, (double)delta_db);
+    fflush(s_fp);
+}

--- a/src/ft8/ft8_log.h
+++ b/src/ft8/ft8_log.h
@@ -1,0 +1,55 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 file-log module
+ *
+ *  Copyright (c) 2026
+ */
+
+/*
+ *  Per-session plain-text file log at /mnt/ft8_logs/x6100_log_<timestamp>.txt.
+ *  Distinct from src/qso_log.* which is a sqlite QSO database.
+ *
+ *  File format (CSV-ish, one record per line):
+ *      RX,<slot_ts>,<rf_hz>,<snr>,<text>
+ *      TX,<slot_ts>,<rf_hz>,<text>
+ *      QSO,<slot_ts>,<remote_call>
+ *      DNF,<slot_ts>,<center_hz>,<delta_db>
+ *  slot_ts is UTC-local "%Y-%m-%d_%H-%M-%S".
+ *
+ *  ft8_log_rx_collect() dedups and queues RX lines until the slot ends;
+ *  ft8_log_rx_flush_slot() writes them out at slot end so the file stays
+ *  chronologically ordered regardless of worker decode timing.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <time.h>
+
+/* Per-RX-slot metadata shared across the ft8 modules. */
+typedef struct {
+    bool     odd;
+    bool     answer_generated;
+    time_t   slot_start;
+    uint64_t base_freq_hz;
+} slot_info_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void ft8_log_init(void);
+void ft8_log_close(void);
+
+void ft8_log_rx_collect(const slot_info_t *info, float freq_hz, int snr, const char *text);
+void ft8_log_rx_flush_slot(const slot_info_t *info);
+
+void ft8_log_tx(time_t slot_start, uint64_t base_freq_hz, uint32_t hz_offset, const char *text);
+void ft8_log_qso(time_t slot_start, const char *remote_call);
+void ft8_log_dnf(time_t slot_start, uint16_t center_hz, float delta_db);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ft8/gfsk.c
+++ b/src/ft8/gfsk.c
@@ -32,6 +32,9 @@ int16_t *gfsk_synth(const uint8_t *symbols, uint16_t n_sym, float f0, float symb
     float    dphi_peak = 2 * M_PI * hmod / n_spsym;
     float    dphi[n_wave + 2 * n_spsym];
     int16_t *samples = malloc(sizeof(int16_t) * n_wave);
+    if (!samples) {
+        return NULL;
+    }
 
     *n_samples = n_wave;
 

--- a/src/ft8/params.c
+++ b/src/ft8/params.c
@@ -1,0 +1,103 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 persistent tuning parameters
+ *
+ *  Copyright (c) 2026
+ */
+
+#include "params.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+#define PATH_SCAN_START     "/mnt/auto_dnf_scan_start_sec.txt"
+#define PATH_SCAN_END       "/mnt/auto_dnf_scan_end_sec.txt"
+#define PATH_CLEAR_TIME     "/mnt/auto_dnf_clear_time_sec.txt"
+#define PATH_MIN_DELTA_DB   "/mnt/auto_notch_threshold_db.txt"
+
+/* Slot-relative seconds are bounded by the 15s slot period with generous slack. */
+#define RANGE_SEC_MIN       0.0f
+#define RANGE_SEC_MAX       2.0f
+#define RANGE_DB_MIN        0.0f
+#define RANGE_DB_MAX        120.0f
+
+static void write_default(const char *path, float default_val, const char *fmt) {
+    FILE *wf = fopen(path, "w");
+    if (!wf) return;
+    fprintf(wf, fmt, (double)default_val);
+    fclose(wf);
+}
+
+static bool parse_trimmed_float(const char *buf, float *out) {
+    char *end = NULL;
+    errno = 0;
+    float v = strtof(buf, &end);
+    if ((errno != 0) || (end == buf) || !isfinite(v)) {
+        return false;
+    }
+    while (end && *end && isspace((unsigned char)*end)) {
+        end++;
+    }
+    if ((end == NULL) || (*end != '\0')) {
+        return false;
+    }
+    *out = v;
+    return true;
+}
+
+static void load_float_txt(const char *path,
+                           float default_val,
+                           float min_val,
+                           float max_val,
+                           const char *write_fmt,
+                           float *out) {
+    FILE *f = fopen(path, "r");
+    if (!f) {
+        if (errno == ENOENT) {
+            write_default(path, default_val, write_fmt);
+        }
+        *out = default_val;
+        return;
+    }
+
+    char buf[64] = {0};
+    bool ok = false;
+    if (fgets(buf, sizeof(buf), f)) {
+        float v;
+        if (parse_trimmed_float(buf, &v) && (v >= min_val) && (v <= max_val)) {
+            *out = v;
+            ok = true;
+        }
+    }
+    fclose(f);
+
+    if (!ok) {
+        *out = default_val;
+        write_default(path, default_val, write_fmt);
+    }
+}
+
+void ft8_params_load(ft8_tuning_t *out) {
+    if (!out) return;
+
+    load_float_txt(PATH_SCAN_START,
+                   FT8_AUTO_DNF_SCAN_START_SEC_DEFAULT,
+                   RANGE_SEC_MIN, RANGE_SEC_MAX, "%.3f\n",
+                   &out->scan_start_sec);
+    load_float_txt(PATH_SCAN_END,
+                   FT8_AUTO_DNF_SCAN_END_SEC_DEFAULT,
+                   RANGE_SEC_MIN, RANGE_SEC_MAX, "%.3f\n",
+                   &out->scan_end_sec);
+    load_float_txt(PATH_CLEAR_TIME,
+                   FT8_AUTO_DNF_CLEAR_TIME_SEC_DEFAULT,
+                   RANGE_SEC_MIN, RANGE_SEC_MAX, "%.3f\n",
+                   &out->clear_time_sec);
+    load_float_txt(PATH_MIN_DELTA_DB,
+                   FT8_AUTO_DNF_MIN_DELTA_DB_DEFAULT,
+                   RANGE_DB_MIN, RANGE_DB_MAX, "%.1f\n",
+                   &out->min_delta_db);
+}

--- a/src/ft8/params.h
+++ b/src/ft8/params.h
@@ -1,0 +1,50 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 persistent tuning parameters
+ *
+ *  Copyright (c) 2026
+ */
+
+/*
+ *  Small plain-text parameter files under /mnt/ tweaked by the user to tune
+ *  the FT8 Auto-DNF detector without recompiling. Each file holds one float.
+ *
+ *  Files created with defaults on first boot; values read back and clipped
+ *  to sane ranges on every dialog entry. Out-of-range values are rewritten
+ *  with the default so the file stays self-describing.
+ *
+ *      /mnt/auto_dnf_scan_start_sec.txt   (default 0.25)
+ *      /mnt/auto_dnf_scan_end_sec.txt     (default 0.75)
+ *      /mnt/auto_dnf_clear_time_sec.txt   (default 0.25)
+ *      /mnt/auto_notch_threshold_db.txt   (default 40.0)
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+/* Compiled-in defaults mirrored to disk if the file is absent. */
+#define FT8_AUTO_DNF_SCAN_START_SEC_DEFAULT  0.25f
+#define FT8_AUTO_DNF_SCAN_END_SEC_DEFAULT    0.75f
+#define FT8_AUTO_DNF_CLEAR_TIME_SEC_DEFAULT  0.25f
+#define FT8_AUTO_DNF_MIN_DELTA_DB_DEFAULT    40.0f
+
+typedef struct {
+    float scan_start_sec;   /* slot_start-relative scan window begin */
+    float scan_end_sec;     /* slot_start-relative scan window end */
+    float clear_time_sec;   /* slot_start-relative clear moment */
+    float min_delta_db;     /* minimum peak prominence to notch */
+} ft8_tuning_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Load all four parameters from disk; missing/invalid values rewritten with
+ * defaults. Always populates every field in *out. */
+void ft8_params_load(ft8_tuning_t *out);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ft8/qso.cpp
+++ b/src/ft8/qso.cpp
@@ -76,9 +76,10 @@ std::string Candidate::get_tx_text(std::string local_callsign, std::string local
 }
 
 void Candidate::save_qso(save_qso_cb_t save_qso_cb) {
-    if (can_be_saved())
+    if (save_qso_cb && can_be_saved()) {
         save_qso_cb(_remote_callsign.c_str(), _grid.c_str(), _rcvd_snr, _sent_snr);
         _saved = true;
+    }
 }
 
 FTxQsoProcessor::FTxQsoProcessor(std::string local_callsign, std::string local_qth, save_qso_cb_t save_qso_cb, int max_repeats) {
@@ -107,6 +108,11 @@ void FTxQsoProcessor::add_rx_text(std::string text, const int snr, ftx_msg_meta_
 
     std::vector<std::string> tokens = split_text(text);
 
+    // Safety: check if tokens is empty
+    if (tokens.empty()) {
+        return;
+    }
+
     if ((tokens.size() >= 5) && (text.find(';') != text.npos)) {
         // "A2AA RR73; R2RFE <RP79AA> +05"
         std::vector<std::string> new_tokens;
@@ -122,12 +128,16 @@ void FTxQsoProcessor::add_rx_text(std::string text, const int snr, ftx_msg_meta_
         tokens = new_tokens;
     }
 
-    for (auto it = tokens.begin(); it != tokens.end(); it++) {
-        if (it->at(0) == '<') {
-            *it = it->substr(1, it->length() - 2);
-        }
+    // Safety: check if tokens became empty after processing
+    if (tokens.empty()) {
+        return;
     }
 
+    for (auto &token : tokens) {
+        if (!token.empty() && token[0] == '<') {
+            token = token.substr(1, token.length() - 2);
+        }
+    }
 
     if (tokens[0] == "CQ") {
         process_cq(meta, tokens, snr);
@@ -429,4 +439,13 @@ bool ftx_qso_processor_can_save_qso(FTxQsoProcessor *p) {
 
 bool ftx_qso_processor_force_save_qso(FTxQsoProcessor *p) {
     return p->force_save_qso();
+}
+
+bool FTxQsoProcessor::has_current() {
+    return _cur_candidate != NULL;
+}
+
+bool ftx_qso_processor_has_current(FTxQsoProcessor *p) {
+    if (!p) return false;
+    return p->has_current();
 }

--- a/src/ft8/qso.h
+++ b/src/ft8/qso.h
@@ -31,6 +31,7 @@ typedef struct {
 typedef struct {
     char msg[35];
     int  repeats;
+    bool force_free_text;  ///< when true, encode as FT8 free text only (e.g. Free MSG)
 } ftx_tx_msg_t;
 
 typedef void (*save_qso_cb_t)(const char *remote_callsign, const char *remote_grid, const int r_snr, const int s_snr);
@@ -92,6 +93,7 @@ class FTxQsoProcessor {
 
     bool can_save_qso();
     bool force_save_qso();
+    bool has_current();
 
   private:
     bool          _auto    = true;
@@ -127,6 +129,7 @@ extern void ftx_qso_processor_start_qso(FTxQsoProcessor *p, ftx_msg_meta_t *meta
 
 extern bool ftx_qso_processor_can_save_qso(FTxQsoProcessor *p);
 extern bool ftx_qso_processor_force_save_qso(FTxQsoProcessor *p);
+extern bool ftx_qso_processor_has_current(FTxQsoProcessor *p);
 
 #ifdef __cplusplus
 }

--- a/src/ft8/qso_state.c
+++ b/src/ft8/qso_state.c
@@ -1,0 +1,275 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 QSO state
+ *
+ *  Copyright (c) 2026
+ */
+
+#include "qso_state.h"
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../qth/qth.h"
+
+struct qso_state_s {
+    pthread_mutex_t mux;
+
+    ftx_tx_msg_t    tx_msg;
+    bool            tx_time_slot;
+    char            active_call[16];
+
+    bool            qso_tx_exhausted;
+    bool            autosel_recover_mode;
+    bool            autosel_qso_active;
+    uint8_t         autosel_grid_tx_count;
+
+    bool            pending_to_me_valid;
+    bool            pending_to_me_odd;
+    ftx_msg_meta_t  pending_to_me_meta;
+
+    bool            pending_grid_to_me_valid;
+    bool            pending_grid_to_me_odd;
+    ftx_msg_meta_t  pending_grid_to_me_meta;
+};
+
+qso_state_t *qso_state_create(void) {
+    qso_state_t *s = (qso_state_t *)calloc(1, sizeof(*s));
+    if (!s) return NULL;
+    pthread_mutex_init(&s->mux, NULL);
+    return s;
+}
+
+void qso_state_destroy(qso_state_t *s) {
+    if (!s) return;
+    pthread_mutex_destroy(&s->mux);
+    free(s);
+}
+
+static inline void lock(qso_state_t *s)   { pthread_mutex_lock(&s->mux); }
+static inline void unlock(qso_state_t *s) { pthread_mutex_unlock(&s->mux); }
+
+void qso_state_lock(qso_state_t *s)   { lock(s); }
+void qso_state_unlock(qso_state_t *s) { unlock(s); }
+
+ftx_tx_msg_t *qso_state_tx_msg_locked(qso_state_t *s) {
+    return s ? &s->tx_msg : NULL;
+}
+
+void qso_state_reset_all(qso_state_t *s) {
+    if (!s) return;
+    lock(s);
+    memset(&s->tx_msg, 0, sizeof(s->tx_msg));
+    s->tx_time_slot             = false;
+    s->active_call[0]           = '\0';
+    s->qso_tx_exhausted         = false;
+    s->autosel_recover_mode     = false;
+    s->autosel_qso_active       = false;
+    s->autosel_grid_tx_count    = 0;
+    s->pending_to_me_valid      = false;
+    s->pending_to_me_odd        = false;
+    memset(&s->pending_to_me_meta, 0, sizeof(s->pending_to_me_meta));
+    s->pending_grid_to_me_valid = false;
+    s->pending_grid_to_me_odd   = false;
+    memset(&s->pending_grid_to_me_meta, 0, sizeof(s->pending_grid_to_me_meta));
+    unlock(s);
+}
+
+void qso_state_get_tx_msg(const qso_state_t *s, ftx_tx_msg_t *out) {
+    if (!s || !out) return;
+    pthread_mutex_lock((pthread_mutex_t *)&s->mux);
+    *out = s->tx_msg;
+    pthread_mutex_unlock((pthread_mutex_t *)&s->mux);
+}
+
+void qso_state_set_tx_msg(qso_state_t *s, const ftx_tx_msg_t *in) {
+    if (!s || !in) return;
+    lock(s);
+    s->tx_msg = *in;
+    unlock(s);
+}
+
+void qso_state_clear_tx_msg(qso_state_t *s) {
+    if (!s) return;
+    lock(s);
+    s->tx_msg.msg[0]          = '\0';
+    s->tx_msg.repeats         = 0;
+    s->tx_msg.force_free_text = false;
+    unlock(s);
+}
+
+bool qso_state_tx_msg_empty(const qso_state_t *s) {
+    if (!s) return true;
+    pthread_mutex_lock((pthread_mutex_t *)&s->mux);
+    bool empty = (s->tx_msg.msg[0] == '\0');
+    pthread_mutex_unlock((pthread_mutex_t *)&s->mux);
+    return empty;
+}
+
+int qso_state_tx_msg_repeats(const qso_state_t *s) {
+    if (!s) return 0;
+    pthread_mutex_lock((pthread_mutex_t *)&s->mux);
+    int r = s->tx_msg.repeats;
+    pthread_mutex_unlock((pthread_mutex_t *)&s->mux);
+    return r;
+}
+
+void qso_state_tx_msg_dec_repeats(qso_state_t *s) {
+    if (!s) return;
+    lock(s);
+    if (s->tx_msg.repeats > 0) s->tx_msg.repeats--;
+    unlock(s);
+}
+
+bool qso_state_tx_time_slot(const qso_state_t *s) {
+    if (!s) return false;
+    pthread_mutex_lock((pthread_mutex_t *)&s->mux);
+    bool v = s->tx_time_slot;
+    pthread_mutex_unlock((pthread_mutex_t *)&s->mux);
+    return v;
+}
+
+void qso_state_set_tx_time_slot(qso_state_t *s, bool odd) {
+    if (!s) return;
+    lock(s);
+    s->tx_time_slot = odd;
+    unlock(s);
+}
+
+void qso_state_get_active_call(const qso_state_t *s, char *out, size_t out_sz) {
+    if (!s || !out || out_sz == 0) { if (out && out_sz) out[0] = '\0'; return; }
+    pthread_mutex_lock((pthread_mutex_t *)&s->mux);
+    snprintf(out, out_sz, "%s", s->active_call);
+    pthread_mutex_unlock((pthread_mutex_t *)&s->mux);
+}
+
+void qso_state_set_active_call(qso_state_t *s, const char *call) {
+    if (!s) return;
+    lock(s);
+    if (call) snprintf(s->active_call, sizeof(s->active_call), "%s", call);
+    else      s->active_call[0] = '\0';
+    unlock(s);
+}
+
+void qso_state_clear_active_call(qso_state_t *s) {
+    qso_state_set_active_call(s, NULL);
+}
+
+/* Generic bool accessors - avoid code duplication for the many bool fields. */
+static inline bool getb(const qso_state_t *s, const bool *p) {
+    pthread_mutex_lock((pthread_mutex_t *)&s->mux);
+    bool v = *p;
+    pthread_mutex_unlock((pthread_mutex_t *)&s->mux);
+    return v;
+}
+static inline void setb(qso_state_t *s, bool *p, bool v) {
+    lock(s); *p = v; unlock(s);
+}
+
+bool qso_state_tx_exhausted(const qso_state_t *s)          { return s ? getb(s, &s->qso_tx_exhausted) : false; }
+void qso_state_set_tx_exhausted(qso_state_t *s, bool v)    { if (s) setb(s, &s->qso_tx_exhausted, v); }
+bool qso_state_autosel_recover(const qso_state_t *s)       { return s ? getb(s, &s->autosel_recover_mode) : false; }
+void qso_state_set_autosel_recover(qso_state_t *s, bool v) { if (s) setb(s, &s->autosel_recover_mode, v); }
+bool qso_state_autosel_qso_active(const qso_state_t *s)    { return s ? getb(s, &s->autosel_qso_active) : false; }
+void qso_state_set_autosel_qso_active(qso_state_t *s, bool v) { if (s) setb(s, &s->autosel_qso_active, v); }
+
+uint8_t qso_state_autosel_grid_tx_count(const qso_state_t *s) {
+    if (!s) return 0;
+    pthread_mutex_lock((pthread_mutex_t *)&s->mux);
+    uint8_t v = s->autosel_grid_tx_count;
+    pthread_mutex_unlock((pthread_mutex_t *)&s->mux);
+    return v;
+}
+void qso_state_set_autosel_grid_tx_count(qso_state_t *s, uint8_t v) {
+    if (!s) return;
+    lock(s); s->autosel_grid_tx_count = v; unlock(s);
+}
+void qso_state_inc_autosel_grid_tx_count(qso_state_t *s) {
+    if (!s) return;
+    lock(s);
+    if (s->autosel_grid_tx_count < 255) s->autosel_grid_tx_count++;
+    unlock(s);
+}
+
+/* Pending to-me. */
+
+bool qso_state_has_pending_to_me(const qso_state_t *s) { return s ? getb(s, &s->pending_to_me_valid) : false; }
+
+void qso_state_set_pending_to_me(qso_state_t *s, const ftx_msg_meta_t *meta, bool odd) {
+    if (!s || !meta) return;
+    lock(s);
+    s->pending_to_me_meta  = *meta;
+    s->pending_to_me_odd   = odd;
+    s->pending_to_me_valid = true;
+    unlock(s);
+}
+
+void qso_state_get_pending_to_me(const qso_state_t *s, ftx_msg_meta_t *out, bool *out_odd) {
+    if (!s) return;
+    pthread_mutex_lock((pthread_mutex_t *)&s->mux);
+    if (out)     *out     = s->pending_to_me_meta;
+    if (out_odd) *out_odd = s->pending_to_me_odd;
+    pthread_mutex_unlock((pthread_mutex_t *)&s->mux);
+}
+
+void qso_state_clear_pending_to_me(qso_state_t *s) {
+    if (!s) return;
+    lock(s);
+    s->pending_to_me_valid = false;
+    s->pending_to_me_odd   = false;
+    memset(&s->pending_to_me_meta, 0, sizeof(s->pending_to_me_meta));
+    unlock(s);
+}
+
+bool qso_state_has_pending_grid_to_me(const qso_state_t *s) { return s ? getb(s, &s->pending_grid_to_me_valid) : false; }
+
+void qso_state_set_pending_grid_to_me(qso_state_t *s, const ftx_msg_meta_t *meta, bool odd) {
+    if (!s || !meta) return;
+    lock(s);
+    s->pending_grid_to_me_meta  = *meta;
+    s->pending_grid_to_me_odd   = odd;
+    s->pending_grid_to_me_valid = true;
+    unlock(s);
+}
+
+void qso_state_get_pending_grid_to_me(const qso_state_t *s, ftx_msg_meta_t *out, bool *out_odd) {
+    if (!s) return;
+    pthread_mutex_lock((pthread_mutex_t *)&s->mux);
+    if (out)     *out     = s->pending_grid_to_me_meta;
+    if (out_odd) *out_odd = s->pending_grid_to_me_odd;
+    pthread_mutex_unlock((pthread_mutex_t *)&s->mux);
+}
+
+void qso_state_clear_pending_grid_to_me(qso_state_t *s) {
+    if (!s) return;
+    lock(s);
+    s->pending_grid_to_me_valid = false;
+    s->pending_grid_to_me_odd   = false;
+    memset(&s->pending_grid_to_me_meta, 0, sizeof(s->pending_grid_to_me_meta));
+    unlock(s);
+}
+
+void qso_state_clear_qso_related(qso_state_t *s) {
+    if (!s) return;
+    lock(s);
+    s->qso_tx_exhausted         = false;
+    s->autosel_recover_mode     = false;
+    s->pending_to_me_valid      = false;
+    s->active_call[0]           = '\0';
+    s->autosel_qso_active       = false;
+    s->autosel_grid_tx_count    = 0;
+    s->pending_grid_to_me_valid = false;
+    unlock(s);
+}
+
+bool qso_state_is_grid_exchange_msg(const char *msg) {
+    if (!msg || msg[0] == '\0') return false;
+    char t1[16] = {0};
+    char t2[16] = {0};
+    char t3[16] = {0};
+    if (sscanf(msg, "%15s %15s %15s", t1, t2, t3) != 3) return false;
+    return qth_grid_check(t3);
+}

--- a/src/ft8/qso_state.h
+++ b/src/ft8/qso_state.h
@@ -1,0 +1,102 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 QSO state
+ *
+ *  Copyright (c) 2026
+ */
+
+/*
+ *  Thread-safe container for the scattered per-QSO state that used to live
+ *  as free-floating static variables in dialog_ft8.c:
+ *
+ *      tx_msg                      queued TX message for the next TX slot
+ *      tx_time_slot                which slot (odd/even) to TX in
+ *      qso_active_call             other station's callsign for in-progress QSO
+ *      qso_tx_exhausted            TX repeats exhausted but QSO still alive
+ *      autosel_recover_mode        allow AutoSel to replace the current QSO
+ *      autosel_qso_active          current QSO was started by AutoSel
+ *      autosel_grid_tx_count       how many times we have sent our grid
+ *      pending_to_me_*             unanswered call-to-us while TX was busy
+ *      pending_grid_to_me_*        grid-stage priority switch target
+ *
+ *  All access via this API is mutex-protected. Business logic in the
+ *  session loop reads/writes through these accessors - values are never
+ *  exposed as globals.
+ *
+ *  Higher-level helpers (reset_all, clear_qso_pending) make batch updates
+ *  atomic so the session loop cannot observe half-updated state.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "qso.h"  /* ftx_tx_msg_t, ftx_msg_meta_t */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct qso_state_s qso_state_t;
+
+qso_state_t *qso_state_create(void);
+void         qso_state_destroy(qso_state_t *s);
+
+/* Bulk reset: clear every field back to "no QSO, no pending, no TX". */
+void qso_state_reset_all(qso_state_t *s);
+
+/* tx_msg accessors. set() takes ownership of the contents - text is copied. */
+void qso_state_get_tx_msg(const qso_state_t *s, ftx_tx_msg_t *out);
+void qso_state_set_tx_msg(qso_state_t *s, const ftx_tx_msg_t *in);
+void qso_state_clear_tx_msg(qso_state_t *s);
+bool qso_state_tx_msg_empty(const qso_state_t *s);
+int  qso_state_tx_msg_repeats(const qso_state_t *s);
+void qso_state_tx_msg_dec_repeats(qso_state_t *s);
+
+/* Mutable borrow: returns a pointer to the internal tx_msg. Caller must hold
+ * the state's lock via qso_state_lock()/unlock() around the critical region
+ * if it reads/writes multiple fields atomically with ftx_qso_processor_*. */
+void qso_state_lock(qso_state_t *s);
+void qso_state_unlock(qso_state_t *s);
+ftx_tx_msg_t *qso_state_tx_msg_locked(qso_state_t *s);
+
+bool         qso_state_tx_time_slot(const qso_state_t *s);
+void         qso_state_set_tx_time_slot(qso_state_t *s, bool odd);
+
+void         qso_state_get_active_call(const qso_state_t *s, char *out, size_t out_sz);
+void         qso_state_set_active_call(qso_state_t *s, const char *call);
+void         qso_state_clear_active_call(qso_state_t *s);
+
+bool         qso_state_tx_exhausted(const qso_state_t *s);
+void         qso_state_set_tx_exhausted(qso_state_t *s, bool v);
+bool         qso_state_autosel_recover(const qso_state_t *s);
+void         qso_state_set_autosel_recover(qso_state_t *s, bool v);
+bool         qso_state_autosel_qso_active(const qso_state_t *s);
+void         qso_state_set_autosel_qso_active(qso_state_t *s, bool v);
+uint8_t      qso_state_autosel_grid_tx_count(const qso_state_t *s);
+void         qso_state_set_autosel_grid_tx_count(qso_state_t *s, uint8_t v);
+void         qso_state_inc_autosel_grid_tx_count(qso_state_t *s);
+
+/* Pending replies. */
+bool qso_state_has_pending_to_me(const qso_state_t *s);
+void qso_state_set_pending_to_me(qso_state_t *s, const ftx_msg_meta_t *meta, bool odd);
+void qso_state_get_pending_to_me(const qso_state_t *s, ftx_msg_meta_t *out, bool *out_odd);
+void qso_state_clear_pending_to_me(qso_state_t *s);
+
+bool qso_state_has_pending_grid_to_me(const qso_state_t *s);
+void qso_state_set_pending_grid_to_me(qso_state_t *s, const ftx_msg_meta_t *meta, bool odd);
+void qso_state_get_pending_grid_to_me(const qso_state_t *s, ftx_msg_meta_t *out, bool *out_odd);
+void qso_state_clear_pending_grid_to_me(qso_state_t *s);
+
+/* Convenience: clear all "no current QSO" state at once. */
+void qso_state_clear_qso_related(qso_state_t *s);
+
+/* Is msg a three-token "DE GRID" exchange? */
+bool qso_state_is_grid_exchange_msg(const char *msg);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ft8/table_view.c
+++ b/src/ft8/table_view.c
@@ -1,0 +1,370 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 message table view
+ *
+ *  Copyright (c) 2026
+ */
+
+#include "table_view.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "../events.h"
+
+/*
+ *  Cell data is owned by a fixed-size ring pool. We do NOT use LVGL's
+ *  cell user_data API: lv_table_set_cell_user_data() internally calls
+ *  lv_mem_free() on the previous user_data pointer (treating it as a
+ *  malloc'd buffer), which would crash on our pool indices. Instead we
+ *  keep a parallel s_row_cell[] mapping table row -> cell_data_t* in
+ *  this module, and never touch LVGL's user_data slot at all.
+ *
+ *  Size invariant:
+ *      CELL_POOL_SIZE  >= MAX_TABLE_MSG + CLEAN_N_ROWS
+ *  Worst case, the table holds MAX_TABLE_MSG rows; one pending push
+ *  touches the next slot before truncate_oldest() runs. Any slot that
+ *  the ring write cursor is about to overwrite is guaranteed to have
+ *  been truncated out of the table by that point.
+ */
+
+#define MAX_TABLE_MSG               512
+#define CLEAN_N_ROWS                 64
+#define CELL_POOL_SIZE              576  /* MAX_TABLE_MSG + CLEAN_N_ROWS */
+#define TABLE_MAX_ROWS_INTERNAL     576  /* upper bound on row index used */
+#define WAIT_SYNC_TEXT              "Wait sync"
+
+static cell_data_t            s_pool[CELL_POOL_SIZE];
+static uint16_t               s_pool_write = 0;
+static cell_data_t           *s_row_cell[TABLE_MAX_ROWS_INTERNAL]; /* row -> pool entry, NULL if none */
+
+static lv_obj_t              *s_table      = NULL;
+static table_view_press_cb_t  s_press_cb   = NULL;
+static table_view_actions_t   s_actions    = {0};
+
+static inline cell_data_t *row_cell(uint16_t r) {
+    if (r >= TABLE_MAX_ROWS_INTERNAL) return NULL;
+    return s_row_cell[r];
+}
+
+static inline void set_row_cell(uint16_t r, cell_data_t *cd) {
+    if (r >= TABLE_MAX_ROWS_INTERNAL) return;
+    s_row_cell[r] = cd;
+}
+
+static cell_data_t *pool_alloc_and_copy(const cell_data_t *src) {
+    cell_data_t *c = &s_pool[s_pool_write];
+    s_pool_write = (uint16_t)((s_pool_write + 1u) % CELL_POOL_SIZE);
+    *c = *src;
+    c->text[sizeof(c->text) - 1] = '\0';
+    return c;
+}
+
+static void truncate_oldest(void) {
+    if (!s_table) return;
+
+    uint16_t rows = lv_table_get_row_cnt(s_table);
+    if (rows <= MAX_TABLE_MSG) return;
+
+    lv_table_t *tbl = (lv_table_t *)s_table;
+    lv_coord_t  removed_height = 0;
+    for (size_t i = 0; i < CLEAN_N_ROWS; i++) {
+        removed_height += tbl->row_h[i];
+    }
+    if (tbl->row_act > CLEAN_N_ROWS) {
+        tbl->row_act -= CLEAN_N_ROWS;
+    } else {
+        tbl->row_act = 0;
+    }
+
+    /* Shift rows up: LVGL copies cell text, our parallel s_row_cell[]
+     * gets memmove'd in lockstep. No allocations, no frees, and we never
+     * touch LVGL's user_data slot. */
+    for (uint16_t i = CLEAN_N_ROWS; i < rows; i++) {
+        const char *val = lv_table_get_cell_value(s_table, i, 0);
+        lv_table_set_cell_value(s_table, (uint16_t)(i - CLEAN_N_ROWS), 0, val ? val : "");
+    }
+    if (rows > CLEAN_N_ROWS) {
+        memmove(&s_row_cell[0], &s_row_cell[CLEAN_N_ROWS],
+                (size_t)(rows - CLEAN_N_ROWS) * sizeof(s_row_cell[0]));
+    }
+    /* Zero out the tail entries that were just shifted away. */
+    for (uint16_t i = (uint16_t)(rows - CLEAN_N_ROWS); i < rows; i++) {
+        set_row_cell(i, NULL);
+    }
+
+    rows = (uint16_t)(rows - CLEAN_N_ROWS);
+    lv_table_set_row_cnt(s_table, rows);
+    lv_obj_scroll_by_bounded(s_table, 0, removed_height, LV_ANIM_OFF);
+}
+
+/* Return true if this cell_data_t matches an RX-header row ("RX ..."). */
+static bool is_rx_header(const cell_data_t *cd) {
+    return cd && (cd->cell_type == CELL_RX_INFO) &&
+           (strncmp(cd->text, "RX ", 3) == 0);
+}
+
+void table_view_push_ui(const cell_data_t *src) {
+    if (!s_table || !src) return;
+
+    truncate_oldest();
+
+    uint16_t rows = lv_table_get_row_cnt(s_table);
+    if ((rows == 1) && (strcmp(lv_table_get_cell_value(s_table, 0, 0), WAIT_SYNC_TEXT) == 0)) {
+        /* The single "Wait sync" placeholder is about to be replaced. */
+        rows = 0;
+    }
+
+    /* Row autoscroll: keep scrolled-to-bottom unless the user moved away. */
+    uint16_t selected_row = 0;
+    uint16_t selected_col = 0;
+    lv_table_get_selected_cell(s_table, &selected_row, &selected_col);
+    bool scroll = (rows == (uint16_t)(selected_row + 1));
+
+    /* In-place RX-header collapse: replace the last row text instead of
+     * appending another identical "RX ..." marker. */
+    if (is_rx_header(src) && (rows > 0)) {
+        uint16_t last = (uint16_t)(rows - 1);
+        cell_data_t *last_cd = row_cell(last);
+        if (last_cd && is_rx_header(last_cd)) {
+            strncpy(last_cd->text, src->text, sizeof(last_cd->text) - 1);
+            last_cd->text[sizeof(last_cd->text) - 1] = '\0';
+            lv_table_set_cell_value(s_table, last, 0, last_cd->text);
+            return;
+        }
+    }
+
+    cell_data_t *stored = pool_alloc_and_copy(src);
+    lv_table_set_cell_value(s_table, rows, 0, stored->text);
+    set_row_cell(rows, stored);
+
+    if (scroll) {
+        static int32_t c = LV_KEY_DOWN;
+        lv_event_send(s_table, LV_EVENT_KEY, &c);
+    }
+}
+
+void table_view_add_msg_cb(void *data) {
+    table_view_push_ui((const cell_data_t *)data);
+}
+
+void table_view_reset(void) {
+    if (!s_table) return;
+
+    /* Clear our parallel row->cell map; LVGL's user_data slot is never
+     * touched (it stays NULL), so there is no stale-pointer free path
+     * during set_row_cnt() shrink. */
+    memset(s_row_cell, 0, sizeof(s_row_cell));
+    lv_table_set_row_cnt(s_table, 1);
+    lv_table_set_cell_value(s_table, 0, 0, WAIT_SYNC_TEXT);
+    s_pool_write = 0;
+}
+
+/* -------- LVGL event plumbing ------------------------------------------ */
+
+static void draw_part_begin_cb(lv_event_t *e) {
+    lv_obj_t               *obj = lv_event_get_target(e);
+    lv_obj_draw_part_dsc_t *dsc = lv_event_get_draw_part_dsc(e);
+
+    if (dsc->part != LV_PART_ITEMS) return;
+
+    uint32_t row = dsc->id / lv_table_get_col_cnt(obj);
+    uint32_t col = dsc->id - row * lv_table_get_col_cnt(obj);
+    (void)col;
+    cell_data_t *cd = row_cell((uint16_t)row);
+
+    dsc->rect_dsc->bg_opa = LV_OPA_50;
+
+    if (!cd) {
+        dsc->label_dsc->align = LV_TEXT_ALIGN_CENTER;
+        dsc->rect_dsc->bg_color = lv_color_hex(0x303030);
+    } else {
+        switch (cd->cell_type) {
+        case CELL_RX_INFO:
+            dsc->label_dsc->align = LV_TEXT_ALIGN_CENTER;
+            dsc->rect_dsc->bg_color = lv_color_hex(0x303030);
+            break;
+        case CELL_RX_CQ:
+            switch (cd->worked_type) {
+            case SEARCH_WORKED_NO:
+                dsc->rect_dsc->bg_color = lv_color_hex(0x00DD00);
+                break;
+            case SEARCH_WORKED_YES:
+                dsc->label_dsc->opa = LV_OPA_90;
+                dsc->rect_dsc->bg_color = lv_color_hex(0x2e5a00);
+                break;
+            case SEARCH_WORKED_SAME_MODE:
+                dsc->label_dsc->decor = LV_TEXT_DECOR_STRIKETHROUGH;
+                dsc->label_dsc->opa   = LV_OPA_80;
+                dsc->rect_dsc->bg_color = lv_color_hex(0x224400);
+                break;
+            }
+            break;
+        case CELL_RX_TO_ME:
+            dsc->rect_dsc->bg_color = lv_color_hex(0xFF0000);
+            break;
+        case CELL_TX_MSG:
+            dsc->rect_dsc->bg_color = lv_color_hex(0x0000FF);
+            break;
+        default:
+            dsc->rect_dsc->bg_color = lv_color_black();
+            break;
+        }
+    }
+
+    uint16_t selected_row;
+    uint16_t selected_col;
+    lv_table_get_selected_cell(obj, &selected_row, &selected_col);
+    if (selected_row == row) {
+        dsc->rect_dsc->bg_color = lv_color_lighten(dsc->rect_dsc->bg_color, 20);
+    }
+}
+
+static void draw_part_end_cb(lv_event_t *e) {
+    lv_obj_t               *obj = lv_event_get_target(e);
+    lv_obj_draw_part_dsc_t *dsc = lv_event_get_draw_part_dsc(e);
+
+    if (dsc->part != LV_PART_ITEMS) return;
+
+    uint32_t row = dsc->id / lv_table_get_col_cnt(obj);
+    uint32_t col = dsc->id - row * lv_table_get_col_cnt(obj);
+    (void)col;
+    cell_data_t *cd = row_cell((uint16_t)row);
+    if (!cd) return;
+
+    if ((cd->cell_type != CELL_RX_MSG) &&
+        (cd->cell_type != CELL_RX_CQ) &&
+        (cd->cell_type != CELL_RX_TO_ME)) {
+        return;
+    }
+
+    char              buf[64];
+    const lv_coord_t  cell_top    = lv_obj_get_style_pad_top(obj, LV_PART_ITEMS);
+    const lv_coord_t  cell_bottom = lv_obj_get_style_pad_bottom(obj, LV_PART_ITEMS);
+    lv_area_t         area;
+
+    dsc->label_dsc->align = LV_TEXT_ALIGN_RIGHT;
+
+    area.y1 = dsc->draw_area->y1 + cell_top;
+    area.y2 = dsc->draw_area->y2 - cell_bottom;
+    area.x2 = dsc->draw_area->x2 - 15;
+    area.x1 = area.x2 - 120;
+
+    snprintf(buf, sizeof(buf), "%i dB", cd->meta.local_snr);
+    lv_draw_label(dsc->draw_ctx, dsc->label_dsc, &area, buf, NULL);
+
+    if (cd->dist > 0) {
+        area.x2 = area.x1 - 10;
+        area.x1 = area.x2 - 200;
+        snprintf(buf, sizeof(buf), "%i km", cd->dist);
+        lv_draw_label(dsc->draw_ctx, dsc->label_dsc, &area, buf, NULL);
+    }
+}
+
+static void cell_press_cb(lv_event_t *e) {
+    (void)e;
+    if (!s_press_cb) return;
+
+    uint16_t row, col;
+    lv_table_get_selected_cell(s_table, &row, &col);
+    (void)col;
+    cell_data_t *cd = row_cell(row);
+    s_press_cb(cd);
+}
+
+static void key_preprocess_cb(lv_event_t *e) {
+    uint32_t *key_ptr = (uint32_t *)lv_event_get_param(e);
+    uint32_t  key     = *key_ptr;
+
+    /* Remote's '+' (top of rotary) should scroll up, '-' should scroll down.
+     * LVGL default binding is the opposite, so swap in PREPROCESS. */
+    if (key == LV_KEY_LEFT) {
+        *key_ptr = LV_KEY_RIGHT;
+        key = LV_KEY_RIGHT;
+    } else if (key == LV_KEY_RIGHT) {
+        *key_ptr = LV_KEY_LEFT;
+        key = LV_KEY_LEFT;
+    }
+
+    switch (key) {
+    case LV_KEY_ESC:
+        if (s_actions.on_close) s_actions.on_close();
+        break;
+    case KEY_VOL_LEFT_EDIT:
+    case KEY_VOL_LEFT_SELECT:
+        if (s_actions.on_vol_change) s_actions.on_vol_change(-1);
+        break;
+    case KEY_VOL_RIGHT_EDIT:
+    case KEY_VOL_RIGHT_SELECT:
+        if (s_actions.on_vol_change) s_actions.on_vol_change(1);
+        break;
+    default:
+        break;
+    }
+}
+
+void table_view_build(lv_obj_t *parent, lv_coord_t x, lv_coord_t y, lv_coord_t w, lv_coord_t h) {
+    s_pool_write = 0;
+    s_press_cb   = NULL;
+    memset(&s_actions, 0, sizeof(s_actions));
+    memset(s_row_cell, 0, sizeof(s_row_cell));
+
+    s_table = lv_table_create(parent);
+    lv_obj_remove_style(s_table, NULL, LV_STATE_ANY | LV_PART_MAIN);
+    lv_obj_add_event_cb(s_table, cell_press_cb, LV_EVENT_PRESSED, NULL);
+    lv_obj_add_event_cb(s_table, key_preprocess_cb,
+                        LV_EVENT_KEY | LV_EVENT_PREPROCESS, NULL);
+    lv_obj_add_event_cb(s_table, draw_part_begin_cb, LV_EVENT_DRAW_PART_BEGIN, NULL);
+    lv_obj_add_event_cb(s_table, draw_part_end_cb,   LV_EVENT_DRAW_PART_END,   NULL);
+
+    lv_obj_set_size(s_table, w, h);
+    lv_obj_set_pos(s_table, x, y);
+
+    lv_table_set_col_cnt(s_table, 1);
+    lv_table_set_col_width(s_table, 0, w - 2);
+
+    lv_obj_set_style_border_width(s_table, 0, LV_PART_ITEMS);
+    lv_obj_set_style_bg_opa(s_table, 192, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(s_table, lv_color_black(), LV_PART_MAIN);
+    lv_obj_set_style_border_width(s_table, 1, LV_PART_MAIN);
+    lv_obj_set_style_border_color(s_table, lv_color_white(), LV_PART_MAIN);
+    lv_obj_set_style_border_opa(s_table, 128, LV_PART_MAIN);
+    lv_obj_set_style_text_color(s_table, lv_color_hex(0xC0C0C0), LV_PART_ITEMS);
+    lv_obj_set_style_pad_top(s_table, 3, LV_PART_ITEMS);
+    lv_obj_set_style_pad_bottom(s_table, 3, LV_PART_ITEMS);
+    lv_obj_set_style_pad_left(s_table, 5, LV_PART_ITEMS);
+    lv_obj_set_style_pad_right(s_table, 0, LV_PART_ITEMS);
+
+    lv_table_set_cell_value(s_table, 0, 0, WAIT_SYNC_TEXT);
+}
+
+void table_view_destroy(void) {
+    if (s_table) {
+        /* LVGL will delete its internal cell strings; we never wrote to
+         * cell user_data, so its NULL slots have nothing to free. */
+        lv_obj_del(s_table);
+        s_table = NULL;
+    }
+    s_press_cb = NULL;
+    memset(&s_actions, 0, sizeof(s_actions));
+    memset(s_row_cell, 0, sizeof(s_row_cell));
+    s_pool_write = 0;
+}
+
+lv_obj_t *table_view_obj(void) {
+    return s_table;
+}
+
+void table_view_set_press_cb(table_view_press_cb_t cb) {
+    s_press_cb = cb;
+}
+
+void table_view_set_actions(const table_view_actions_t *actions) {
+    if (actions) {
+        s_actions = *actions;
+    } else {
+        memset(&s_actions, 0, sizeof(s_actions));
+    }
+}

--- a/src/ft8/table_view.h
+++ b/src/ft8/table_view.h
@@ -1,0 +1,88 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 message table view
+ *
+ *  Copyright (c) 2026
+ */
+
+/*
+ *  Wraps the LVGL lv_table that displays FT8 RX/TX messages. Owns the cell
+ *  backing data in a fixed-size ring pool, so truncate/scroll/close never
+ *  call malloc or free and there is no way to leak or double-free a cell.
+ *
+ *  Usage (UI thread only unless noted):
+ *      table_view_build(parent, x, y, w, h);
+ *      table_view_set_press_cb(on_press);
+ *      table_view_set_actions(&actions);
+ *
+ *      // from worker thread:
+ *      cell_data_t cd = ...;
+ *      scheduler_put(table_view_add_msg_cb, &cd, sizeof(cd));
+ *
+ *      // on dialog close:
+ *      table_view_destroy();
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "lvgl/lvgl.h"
+
+#include "../qso_log.h"
+#include "qso.h"   /* ftx_msg_meta_t */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    CELL_RX_INFO = 0,
+    CELL_RX_MSG,
+    CELL_RX_CQ,
+    CELL_RX_TO_ME,
+    CELL_TX_MSG,
+} ft8_cell_type_t;
+
+typedef struct {
+    ft8_cell_type_t         cell_type;
+    int16_t                 dist;
+    bool                    odd;
+    ftx_msg_meta_t          meta;
+    char                    text[64];
+    qso_log_search_worked_t worked_type;
+} cell_data_t;
+
+/* Optional dialog-level actions invoked from the table's key handler. */
+typedef struct {
+    void (*on_close)(void);           /* LV_KEY_ESC */
+    void (*on_vol_change)(int32_t d); /* KEY_VOL_*_EDIT/SELECT */
+} table_view_actions_t;
+
+/* Fired when a data-bearing row (RX_MSG / RX_CQ / RX_TO_ME) is pressed. */
+typedef void (*table_view_press_cb_t)(const cell_data_t *cell);
+
+void      table_view_build(lv_obj_t *parent, lv_coord_t x, lv_coord_t y, lv_coord_t w, lv_coord_t h);
+void      table_view_destroy(void);
+lv_obj_t *table_view_obj(void);
+
+void table_view_set_press_cb(table_view_press_cb_t cb);
+void table_view_set_actions(const table_view_actions_t *actions);
+
+/* Clear table + ring pool and show a single "Wait sync" placeholder row. */
+void table_view_reset(void);
+
+/* Insert on the UI thread. Prefer the scheduler trampoline below from
+ * worker threads. The text field is used as the visible row content. */
+void table_view_push_ui(const cell_data_t *src);
+
+/* Trampoline that matches scheduler_fn_t signature. Expects 'data' to point
+ * to a cell_data_t value copy that the scheduler will free after this
+ * returns; table_view_push_ui() takes its own snapshot into the ring pool. */
+void table_view_add_msg_cb(void *data);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ft8/tx_worker.c
+++ b/src/ft8/tx_worker.c
@@ -1,0 +1,194 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 TX player
+ *
+ *  Copyright (c) 2026
+ */
+
+#include "tx_worker.h"
+
+#include <math.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "../audio.h"
+#include "../cfg/cfg.h"
+#include "../cfg/subjects.h"
+#include "../params/params.h"
+#include "../radio.h"
+#include "../tx_info.h"
+#include "worker.h"
+
+/* FT8 signal tone relative to USB Dig audio center.
+ *
+ * Two TX modes are supported, switched by cfg.ft8_xit:
+ *   - XIT ON  (default, legacy X6100 behaviour): synth at SIGNAL_FREQ_DEFAULT_HZ
+ *     and shift the radio center frequency by (ft8_tx_freq - SIGNAL_FREQ_DEFAULT_HZ)
+ *     before TX, then restore. Keeps the on-air signal at the user's tuned
+ *     QRG regardless of where in the passband the cursor sits.
+ *   - XIT OFF (WSJT-X style): keep the radio center fixed and synth the tone
+ *     directly at the cursor offset (clamped to the active filter bandwidth).
+ *     Avoids two PLL retunes per slot but the on-air QRG follows the cursor.
+ */
+#define SIGNAL_FREQ_DEFAULT_HZ 1325
+#define MAX_PWR_W         10.0f
+#define GAIN_MIN_DB       (-30.0f)
+#define GAIN_MAX_DB       0.0f
+
+/* FT8 TX must end by 14.5 s into the 15 s slot so the receiver can
+ * resync for the next slot. */
+#define FT8_TX_END_SEC 14.5f
+
+static inline int32_t clamp_i32(int32_t v, int32_t lo, int32_t hi) {
+    if (v < lo) return lo;
+    if (v > hi) return hi;
+    return v;
+}
+
+static atomic_bool s_abort = false;
+
+void tx_worker_request_abort(void) { atomic_store(&s_abort, true); }
+void tx_worker_clear_abort(void)   { atomic_store(&s_abort, false); }
+bool tx_worker_abort_requested(void) { return atomic_load(&s_abort); }
+
+/* ALC-driven gain correction. Bounded so we never feed +>0 dBFS into the
+ * mixer. */
+static float compute_correction(void) {
+    static uint8_t msg_id = 0;
+    float correction = 0.0f;
+    float pwr        = 0.0f;
+    float alc        = 0.0f;
+
+    if (tx_info_refresh(&msg_id, &alc, &pwr, NULL)) {
+        float target_pwr = subject_get_float(cfg.pwr.val);
+        if (target_pwr > MAX_PWR_W) target_pwr = MAX_PWR_W;
+        if (alc > 0.5f) {
+            correction = log10f(log10f(11.1f - alc)) * 20.0f - 0.38f;
+        } else if (target_pwr - pwr > 0.5f) {
+            correction = log10f(target_pwr / (pwr + 0.01f)) * 10.0f;
+        }
+    }
+    return correction;
+}
+
+static inline float clamp_gain(float g) {
+    if (g > GAIN_MAX_DB) return GAIN_MAX_DB;
+    if (g < GAIN_MIN_DB) return GAIN_MIN_DB;
+    return g;
+}
+
+bool tx_worker_run(const char *tx_text, bool force_free_text,
+                   int32_t audio_sample_rate,
+                   float   base_gain_offset,
+                   float   sec_since_slot_start) {
+    if (!tx_text) return false;
+
+    /* Resolve TX mode + tone frequency before generating samples. The XIT
+     * decision is latched once per call so a mid-TX toggle cannot leave us
+     * with a tone at one freq and the radio retuned for another. */
+    bool    xit_mode    = subject_get_int(cfg.ft8_xit.val);
+    int32_t signal_freq;
+    if (xit_mode) {
+        signal_freq = SIGNAL_FREQ_DEFAULT_HZ;
+    } else {
+        int32_t lo = (int32_t)subject_get_int(cfg_cur.filter.low);
+        int32_t hi = (int32_t)subject_get_int(cfg_cur.filter.high);
+        if (hi < lo) { int32_t t = lo; lo = hi; hi = t; }
+        signal_freq = clamp_i32((int32_t)params.ft8_tx_freq.x, lo, hi);
+    }
+
+    int16_t *samples   = NULL;
+    uint32_t n_samples = 0;
+
+    if (!ftx_worker_generate_tx_samples(tx_text, force_free_text,
+                                        (uint32_t)signal_freq,
+                                        (uint32_t)audio_sample_rate,
+                                        &samples, &n_samples)) {
+        return false;
+    }
+
+    /* Tail-align (FT8 only): crop the beginning so TX ends by 14.5 s. */
+    int protocol = subject_get_int(cfg.ft8_protocol.val);
+    uint32_t skip_samples = 0;
+    if (protocol == FTX_PROTOCOL_FT8) {
+        float remain_sec = FT8_TX_END_SEC - sec_since_slot_start;
+        if (remain_sec <= 0.0f) {
+            free(samples);
+            return false;
+        }
+        float burst_sec = (float)n_samples / (float)audio_sample_rate;
+        float skip_sec = burst_sec - remain_sec;
+        if (skip_sec > 0.0f) {
+            skip_samples = (uint32_t)(0.5f + skip_sec * (float)audio_sample_rate);
+            if (skip_samples >= n_samples) {
+                free(samples);
+                return false;
+            }
+        }
+    }
+
+    /* Enforce the 10 W ceiling even if the user dialed higher. */
+    if (subject_get_float(cfg.pwr.val) > MAX_PWR_W) {
+        radio_set_pwr(MAX_PWR_W);
+    }
+
+    /* Playback gain offset: session-persistent learned offset minus whatever
+     * gain the audio mixer happens to be at right now. */
+    float gain_offset        = base_gain_offset + params.ft8_output_gain_offset.x;
+    float play_gain_offset   = audio_set_play_vol(gain_offset + 6.0f);
+    gain_offset             -= play_gain_offset;
+
+    /* Capture radio freq up-front so we can restore it even if XIT is toggled
+     * during TX. In XIT mode the center moves to put the tone at the cursor;
+     * in fixed-VFO mode the radio is left alone. */
+    uint64_t radio_freq = subject_get_int(cfg_cur.fg_freq);
+    if (xit_mode) {
+        radio_set_freq((int32_t)radio_freq + (int32_t)params.ft8_tx_freq.x - SIGNAL_FREQ_DEFAULT_HZ);
+    }
+    radio_set_modem(true);
+
+    float    prev_gain_offset = gain_offset;
+    uint32_t counter          = 0;
+    int16_t *ptr              = samples + skip_samples;
+    n_samples                -= skip_samples;
+
+    bool aborted = false;
+    while (n_samples > 0) {
+        if (atomic_load(&s_abort)) { aborted = true; break; }
+
+        if (counter > 30) {
+            gain_offset += compute_correction() * 0.4f;
+            gain_offset  = clamp_gain(gain_offset);
+        }
+        uint32_t part = (n_samples > 2048u) ? 2048u : n_samples;
+
+        if (gain_offset == prev_gain_offset) {
+            if (gain_offset != 0.0f) {
+                audio_gain_db(ptr, part, gain_offset, ptr);
+            }
+        } else {
+            audio_gain_db_transition(ptr, part, prev_gain_offset, gain_offset, ptr);
+            prev_gain_offset = gain_offset;
+        }
+        audio_play(ptr, part);
+
+        n_samples -= part;
+        ptr       += part;
+        counter++;
+    }
+
+    params_float_set(&params.ft8_output_gain_offset,
+                     gain_offset - base_gain_offset + play_gain_offset);
+    audio_play_wait();
+    radio_set_modem(false);
+    if (xit_mode) {
+        radio_set_freq((int32_t)radio_freq);
+    }
+    free(samples);
+    audio_set_play_vol(params.play_gain_db_f.x);
+
+    return !aborted;
+}

--- a/src/ft8/tx_worker.h
+++ b/src/ft8/tx_worker.h
@@ -1,0 +1,45 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 TX player
+ *
+ *  Copyright (c) 2026
+ */
+
+/*
+ *  Synthesises the TX waveform from tx_msg text and pushes it to the audio
+ *  output, with per-slot ALC-based gain correction. Blocks for the duration
+ *  of one FT8/FT4 slot (~12.6s / ~5.0s) so it is invoked from the decode
+ *  thread between RX frames, the same way the old decode_thread did.
+ *
+ *  State query lets the caller early-abort from outside the thread.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Transmit tx_text at base_freq_hz + 1325 Hz (FT8 signal centre). Returns
+ * true on normal completion, false on immediate failure (generate_tx_samples
+ * failed). The function only returns when TX has finished or an abort flag
+ * was set via tx_worker_request_abort(). */
+bool tx_worker_run(const char *tx_text,
+                   bool force_free_text,
+                   int32_t audio_sample_rate,
+                   float   base_gain_offset,
+                   float   sec_since_slot_start);
+
+/* External early-termination flag. Polled by tx_worker inside its send loop.
+ * Thread-safe via atomic. */
+void tx_worker_request_abort(void);
+void tx_worker_clear_abort(void);
+bool tx_worker_abort_requested(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ft8/worker.c
+++ b/src/ft8/worker.c
@@ -21,13 +21,17 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
+#include <errno.h>
+#include <ctype.h>
 
 #define MAX_CANDIDATES 200
 #define MAX_DECODED_MESSAGES 50
 #define LDPC_ITERATIONS 25
 #define TIME_OSR 4               // Time oversampling rate (symbol subdivision)
 #define FREQ_OSR 2               // Frequency oversampling rate (bin subdivision)
-#define MIN_SCORE 10             // Minimum score for candidate
+#define FTXLIB_MIN_SCORE_DEFAULT 10
+#define FTXLIB_MIN_SCORE_PATH "/mnt/ft8lib_min_score.txt"
 #define DECODE_BLOCK_STRIDE 2    // Try to decode each N block
 #define EARLY_LDPC_ITERATIONS 25 // LDPC iterations on early decoding
 
@@ -44,6 +48,45 @@ static int   nfft;
 
 static uint8_t n_tones;  // Number of tones for generate message and check minimal length for rx
 static uint8_t sync_num; // Length of sync
+
+static int             ft8lib_min_score = FTXLIB_MIN_SCORE_DEFAULT;
+
+static void ftx_min_score_write_default(void) {
+    FILE *wf = fopen(FTXLIB_MIN_SCORE_PATH, "w");
+    if (!wf) return;
+    fprintf(wf, "%d\n", FTXLIB_MIN_SCORE_DEFAULT);
+    fclose(wf);
+}
+
+static void ftx_min_score_load_or_create(void) {
+    FILE *f = fopen(FTXLIB_MIN_SCORE_PATH, "r");
+    if (!f) {
+        if (errno == ENOENT) {
+            ftx_min_score_write_default();
+        }
+        ft8lib_min_score = FTXLIB_MIN_SCORE_DEFAULT;
+        return;
+    }
+    char buf[64] = {0};
+    bool ok = false;
+    if (fgets(buf, sizeof(buf), f)) {
+        char *end = NULL;
+        errno = 0;
+        long v = strtol(buf, &end, 10);
+        if ((errno == 0) && (end != buf) && (v >= 0) && (v <= 32767)) {
+            while (end && *end && isspace((unsigned char)*end)) end++;
+            if ((end != NULL) && (*end == '\0')) {
+                ft8lib_min_score = (int)v;
+                ok = true;
+            }
+        }
+    }
+    fclose(f);
+    if (!ok) {
+        ft8lib_min_score = FTXLIB_MIN_SCORE_DEFAULT;
+        ftx_min_score_write_default();
+    }
+}
 
 static int             num_candidates;
 static ftx_candidate_t candidate_list[MAX_CANDIDATES];
@@ -62,6 +105,7 @@ static int get_message_snr(const ftx_waterfall_t *wf, const ftx_candidate_t *can
  * Init worker
  */
 void ftx_worker_init(int sample_rate, ftx_protocol_t protocol) {
+    ftx_min_score_load_or_create();
     float slot_period;
 
     switch (protocol) {
@@ -79,6 +123,7 @@ void ftx_worker_init(int sample_rate, ftx_protocol_t protocol) {
         break;
     default:
         LV_LOG_ERROR("Unsupported protocol: %lu", protocol);
+        return;
     }
     int num_samples = slot_period * sample_rate;
 
@@ -93,7 +138,19 @@ void ftx_worker_init(int sample_rate, ftx_protocol_t protocol) {
     // TODO: skip bins outside filter
     const int num_bins = sample_rate * symbol_period / 2;
 
-    size_t mag_size = max_blocks * TIME_OSR * FREQ_OSR * num_bins * sizeof(WF_ELEM_T);
+    /* Check for integer overflow before multiplication */
+    if (max_blocks <= 0 || num_bins <= 0) {
+        LV_LOG_ERROR("FT8 worker: invalid dimensions (max_blocks=%d, num_bins=%d)", max_blocks, num_bins);
+        goto error_cleanup;
+    }
+
+    const size_t mag_stride = (size_t)TIME_OSR * (size_t)FREQ_OSR * (size_t)num_bins * sizeof(WF_ELEM_T);
+    if (mag_stride == 0 || (size_t)max_blocks > SIZE_MAX / mag_stride) {
+        LV_LOG_ERROR("FT8 worker: mag_size calculation overflow");
+        goto error_cleanup;
+    }
+
+    size_t mag_size = (size_t)max_blocks * mag_stride;
 
     wf.max_blocks = max_blocks;
     wf.num_bins = num_bins;
@@ -101,6 +158,10 @@ void ftx_worker_init(int sample_rate, ftx_protocol_t protocol) {
     wf.freq_osr = FREQ_OSR;
     wf.block_stride = TIME_OSR * FREQ_OSR * num_bins;
     wf.mag = (uint8_t *)malloc(mag_size);
+    if (!wf.mag) {
+        LV_LOG_ERROR("FT8 worker: wf.mag malloc failed");
+        goto error_cleanup;
+    }
     wf.protocol = protocol;
 
     find_candidates_at = n_tones - sync_num;
@@ -110,10 +171,18 @@ void ftx_worker_init(int sample_rate, ftx_protocol_t protocol) {
     float fft_norm = 2.0f / nfft;
     time_buf = (float complex *)malloc(nfft * sizeof(float complex));
     freq_buf = (float complex *)malloc(nfft * sizeof(float complex));
+    if (!time_buf || !freq_buf) {
+        LV_LOG_ERROR("FT8 worker: time_buf/freq_buf malloc failed");
+        goto error_cleanup;
+    }
     fft = fft_create_plan(nfft, time_buf, freq_buf, LIQUID_FFT_FORWARD, 0);
     frame_window = windowcf_create(nfft);
 
     rx_window = malloc(nfft * sizeof(complex float));
+    if (!rx_window) {
+        LV_LOG_ERROR("FT8 worker: rx_window malloc failed");
+        goto error_cleanup;
+    }
     float window_norm = 2.0f / nfft;
 
     for (uint16_t i = 0; i < nfft; i++) {
@@ -121,20 +190,41 @@ void ftx_worker_init(int sample_rate, ftx_protocol_t protocol) {
     }
 
     ftx_worker_reset();
+    return;
+
+error_cleanup:
+    ftx_worker_free();
 }
 
 /**
  * Cleanup worker
  */
 void ftx_worker_free() {
-    free(wf.mag);
-    windowcf_destroy(frame_window);
+    if (wf.mag) {
+        free(wf.mag);
+        wf.mag = NULL;
+    }
 
-    free(time_buf);
-    free(freq_buf);
-    fft_destroy_plan(fft);
-
-    free(rx_window);
+    if (frame_window) {
+        windowcf_destroy(frame_window);
+        frame_window = NULL;
+    }
+    if (fft) {
+        fft_destroy_plan(fft);
+        fft = NULL;
+    }
+    if (time_buf) {
+        free(time_buf);
+        time_buf = NULL;
+    }
+    if (freq_buf) {
+        free(freq_buf);
+        freq_buf = NULL;
+    }
+    if (rx_window) {
+        free(rx_window);
+        rx_window = NULL;
+    }
     hashtable_delete();
 }
 
@@ -151,10 +241,16 @@ void ftx_worker_reset() {
     }
 }
 
-bool ftx_worker_generate_tx_samples(const char *text, const uint16_t signal_freq, const uint32_t sample_rate,
-                                    int16_t **samples, uint32_t *n_samples) {
+bool ftx_worker_generate_tx_samples(const char *text, bool force_free_text, const uint16_t signal_freq,
+                                    const uint32_t sample_rate, int16_t **samples, uint32_t *n_samples) {
     ftx_message_t    msg;
-    ftx_message_rc_t rc = ftx_message_encode(&msg, &hash_if, text);
+    ftx_message_init(&msg);
+    ftx_message_rc_t rc;
+    if (force_free_text) {
+        rc = ftx_message_encode_free(&msg, text);
+    } else {
+        rc = ftx_message_encode(&msg, &hash_if, text);
+    }
 
     if (rc != FTX_MESSAGE_RC_OK) {
         LV_LOG_ERROR("Cannot parse message %i", rc);
@@ -175,7 +271,12 @@ bool ftx_worker_generate_tx_samples(const char *text, const uint16_t signal_freq
         break;
     }
 
-    *samples = gfsk_synth(tones, n_tones, signal_freq, symbol_bt, symbol_period, sample_rate, n_samples);
+    int16_t *out = gfsk_synth(tones, n_tones, signal_freq, symbol_bt, symbol_period, sample_rate, n_samples);
+    if (!out) {
+        LV_LOG_ERROR("gfsk_synth allocation failed");
+        return false;
+    }
+    *samples = out;
     return true;
 }
 
@@ -228,7 +329,7 @@ void ftx_worker_put_rx_samples(float complex *samples, uint32_t n_samples) {
 void ftx_worker_decode(decoded_msg_cb msg_cb, bool last, void *user_data) {
     if (wf.num_blocks >= find_candidates_at) {
         if (num_candidates == 0) {
-            num_candidates = ftx_find_candidates(&wf, MAX_CANDIDATES, candidate_list, MIN_SCORE);
+            num_candidates = ftx_find_candidates(&wf, MAX_CANDIDATES, candidate_list, ft8lib_min_score);
         } else if (last) {
             // Last decoding
             decode_messages(&wf, &num_candidates, candidate_list, decoded, decoded_hashtable, LDPC_ITERATIONS, msg_cb,
@@ -254,7 +355,7 @@ static void decode_messages(const ftx_waterfall_t *wf, int *num_candidates, ftx_
                             decoded_msg_cb msg_cb, void *user_data) {
     // Go over candidates and attempt to decode messages
 
-    int to_delete_idx[*num_candidates];
+    int to_delete_idx[MAX_CANDIDATES];
     int to_delete_size = 0;
 
     for (int idx = 0; idx < *num_candidates; ++idx) {
@@ -264,6 +365,13 @@ static void decode_messages(const ftx_waterfall_t *wf, int *num_candidates, ftx_
         if ((cand->time_offset + n_tones - sync_num) >= wf->num_blocks) {
             continue;
         }
+        
+        // Safety check: prevent buffer overflow
+        if (to_delete_size >= MAX_CANDIDATES) {
+            LV_LOG_WARN("Too many candidates to delete, truncating to %d", MAX_CANDIDATES);
+            break;
+        }
+        
         to_delete_idx[to_delete_size++] = idx;
 
         ftx_message_t       message;
@@ -284,6 +392,7 @@ static void decode_messages(const ftx_waterfall_t *wf, int *num_candidates, ftx_
         int  idx_hash = message.hash % MAX_DECODED_MESSAGES;
         bool found_empty_slot = false;
         bool found_duplicate = false;
+        int  probes = 0;
         do {
             if (decoded_hashtable[idx_hash] == NULL) {
                 LV_LOG_INFO("Found an empty slot");
@@ -294,10 +403,10 @@ static void decode_messages(const ftx_waterfall_t *wf, int *num_candidates, ftx_
                 found_duplicate = true;
             } else {
                 LV_LOG_INFO("Hash table clash!");
-                // Move on to check the next entry in hash table
                 idx_hash = (idx_hash + 1) % MAX_DECODED_MESSAGES;
+                probes++;
             }
-        } while (!found_empty_slot && !found_duplicate);
+        } while (!found_empty_slot && !found_duplicate && probes < MAX_DECODED_MESSAGES);
 
         if (found_empty_slot) {
             // Fill the empty hashtable slot

--- a/src/ft8/worker.h
+++ b/src/ft8/worker.h
@@ -30,13 +30,14 @@ void ftx_worker_reset();
 
 /// @brief Generate audio samples for TX
 /// @param[in] text message to send
+/// @param[in] force_free_text when true, encode as FT8 free text only (e.g. Free MSG)
 /// @param[in] signal_freq base signal frequency
 /// @param[in] sample_rate output sample rate
 /// @param[out] samples pointer to generated audio samples
 /// @param[out] n_samples count of samples
 /// @return success flag
-bool ftx_worker_generate_tx_samples(const char *text, const uint16_t signal_freq, const uint32_t sample_rate,
-                                    int16_t **samples, uint32_t *n_samples);
+bool ftx_worker_generate_tx_samples(const char *text, bool force_free_text, const uint16_t signal_freq,
+                                    const uint32_t sample_rate, int16_t **samples, uint32_t *n_samples);
 
 /// @brief Process RX audio samples
 /// @param[in] samples audio samples

--- a/src/qso_log.c
+++ b/src/qso_log.c
@@ -20,7 +20,9 @@
 #include <stdio.h>
 
 static sqlite3_stmt     *search_callsign_stmt=NULL;
+static sqlite3_stmt     *search_grid_stmt=NULL;
 static sqlite3          *db = NULL;
+static pthread_mutex_t   db_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 
 static bool create_tables();
@@ -38,10 +40,20 @@ bool qso_log_init() {
 }
 
 void qso_log_destruct() {
+    pthread_mutex_lock(&db_mutex);
+    if (search_callsign_stmt) {
+        sqlite3_finalize(search_callsign_stmt);
+        search_callsign_stmt = NULL;
+    }
+    if (search_grid_stmt) {
+        sqlite3_finalize(search_grid_stmt);
+        search_grid_stmt = NULL;
+    }
     if (db) {
         sqlite3_close(db);
         db = NULL;
     }
+    pthread_mutex_unlock(&db_mutex);
 }
 
 void qso_log_import_adif(const char * path) {
@@ -361,4 +373,44 @@ static bool create_tables() {
     }
 
     return true;
+}
+
+bool qso_log_search_worked_grid(const char *grid, qso_log_mode_t mode, qso_log_band_t band)
+{
+    if (!db || !grid || strlen(grid) == 0) return false;
+
+    pthread_mutex_lock(&db_mutex);
+
+    int rc;
+    if (!search_grid_stmt) {
+        rc = sqlite3_prepare_v3(
+            db,
+            "SELECT 1 FROM qso_log WHERE remote_grid LIKE ? AND band = ? AND mode = ? LIMIT 1",
+            -1,
+            SQLITE_PREPARE_PERSISTENT,
+            &search_grid_stmt,
+            NULL);
+        if (rc != SQLITE_OK) {
+            pthread_mutex_unlock(&db_mutex);
+            return false;
+        }
+    } else {
+        sqlite3_reset(search_grid_stmt);
+        sqlite3_clear_bindings(search_grid_stmt);
+    }
+
+    /* Use prefix match so grid "FN31" matches "FN31" or "FN31xx" */
+    char pattern[32] = {0};
+    snprintf(pattern, sizeof(pattern), "%s%%", grid);
+
+    rc = sqlite3_bind_text(search_grid_stmt, 1, pattern, -1, SQLITE_TRANSIENT);
+    if (rc != SQLITE_OK) { pthread_mutex_unlock(&db_mutex); return false; }
+    rc = sqlite3_bind_int(search_grid_stmt, 2, band);
+    if (rc != SQLITE_OK) { pthread_mutex_unlock(&db_mutex); return false; }
+    rc = sqlite3_bind_int(search_grid_stmt, 3, mode);
+    if (rc != SQLITE_OK) { pthread_mutex_unlock(&db_mutex); return false; }
+
+    bool found = (sqlite3_step(search_grid_stmt) == SQLITE_ROW);
+    pthread_mutex_unlock(&db_mutex);
+    return found;
 }

--- a/src/qso_log.h
+++ b/src/qso_log.h
@@ -82,5 +82,12 @@ qso_log_record_t qso_log_record_create(const char *local_call, const char *remot
  */
 qso_log_search_worked_t qso_log_search_worked(const char *callsign, qso_log_mode_t mode, qso_log_band_t band);
 
+/**
+ * Check whether a given grid square has been worked (any callsign).
+ * Returns true if there is at least one QSO with `remote_grid` matching the provided grid
+ * (prefix match, so passing "FN31" will match "FN31xx").
+ */
+bool qso_log_search_worked_grid(const char *grid, qso_log_mode_t mode, qso_log_band_t band);
+
 
 qso_log_band_t qso_log_freq_to_band(uint64_t freq_hz);

--- a/src/tx_info.c
+++ b/src/tx_info.c
@@ -211,6 +211,14 @@ static void update_tx_info(void *arg) {
     lv_label_set_text_fmt(alc_label, "ALC: %1.1f", alc);
     lv_label_set_text_fmt(vswr_label, "%.2f", vswr);
     lv_label_set_text_fmt(pwr_label, "%.2f", pwr);
+    /* PWR / SWR bars are drawn in obj's DRAW_MAIN_END handler. The labels
+     * only invalidate their own (small) bounding boxes, which does not cover
+     * the bar area. Explicitly invalidate the container so the bars repaint
+     * on every update -- previously we relied on the main_screen spectrum
+     * widget (which fully overlaps tx_info) being invalidated periodically
+     * by spectrum_data(), but FT8 dialog turns the spectrum/waterfall DSP
+     * off, removing that side effect. */
+    lv_obj_invalidate(obj);
     if (params.mag_alc.x) {
         lv_obj_add_flag(alc_label, LV_OBJ_FLAG_HIDDEN);
         msg_tiny_set_text_fmt("ALC: %.1f", alc);

--- a/src/widgets/lv_waterfall.c
+++ b/src/widgets/lv_waterfall.c
@@ -85,13 +85,22 @@ void lv_waterfall_clear_data(lv_obj_t * obj) {
 
     memset(waterfall->dsc->data, 0, waterfall->dsc->data_size);
     lv_img_cache_invalidate_src(waterfall->dsc);
+    lv_obj_invalidate(obj);
 }
 
 void lv_waterfall_add_data(lv_obj_t * obj, float * data, uint16_t cnt) {
+    struct timespec ts = {0, 0};
+    lv_waterfall_add_data_with_ts(obj, data, cnt, ts);
+}
+
+void lv_waterfall_add_data_with_ts(lv_obj_t * obj, float * data, uint16_t cnt, struct timespec ts) {
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
     lv_waterfall_t  *waterfall = (lv_waterfall_t *)obj;
     lv_img_dsc_t    *dsc = waterfall->dsc;
+
+    /* Store timestamp for time-aligned processing (e.g. DNF). */
+    waterfall->frame_ts = ts;
 
     if (!dsc || !waterfall->palette) {
         return;
@@ -120,6 +129,39 @@ void lv_waterfall_add_data(lv_obj_t * obj, float * data, uint16_t cnt) {
 
         lv_img_buf_set_px_color(dsc, x, 0, waterfall->palette[id]);
     }
+
+    lv_img_cache_invalidate_src(dsc);
+    lv_obj_invalidate(obj);
+}
+
+struct timespec lv_waterfall_get_frame_ts(lv_obj_t * obj) {
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_waterfall_t *waterfall = (lv_waterfall_t *)obj;
+    return waterfall->frame_ts;
+}
+
+void lv_waterfall_add_marker_line(lv_obj_t * obj, lv_color_t color) {
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_waterfall_t  *waterfall = (lv_waterfall_t *)obj;
+    lv_img_dsc_t    *dsc = waterfall->dsc;
+
+    if (!dsc) {
+        return;
+    }
+
+    uint32_t line_len = waterfall->line_len;
+
+    /* Scroll down */
+    memmove(dsc->data + line_len, dsc->data, dsc->data_size - line_len);
+
+    /* Paint marker */
+    for (uint32_t x = 0; x < dsc->header.w; x++) {
+        lv_img_buf_set_px_color(dsc, x, 0, color);
+    }
+
+    lv_img_cache_invalidate_src(dsc);
+    lv_obj_invalidate(obj);
 }
 
 void lv_waterfall_set_min(lv_obj_t * obj, int16_t val) {

--- a/src/widgets/lv_waterfall.h
+++ b/src/widgets/lv_waterfall.h
@@ -17,6 +17,8 @@ extern "C" {
 
 #include "lvgl/lvgl.h"
 
+#include <time.h>
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -33,6 +35,8 @@ typedef struct {
 
     int16_t         min;
     int16_t         max;
+
+    struct timespec frame_ts;   /* wall-clock timestamp of most recent PSD frame */
 } lv_waterfall_t;
 
 extern const lv_obj_class_t lv_waterfall_class;
@@ -52,6 +56,15 @@ void lv_waterfall_set_size(lv_obj_t * obj, lv_coord_t w, lv_coord_t h);
 
 void lv_waterfall_clear_data(lv_obj_t * obj);
 void lv_waterfall_add_data(lv_obj_t * obj, float * data, uint16_t cnt);
+
+/* Add data with wall-clock timestamp for time-aligned processing (e.g. DNF). */
+void lv_waterfall_add_data_with_ts(lv_obj_t * obj, float * data, uint16_t cnt, struct timespec ts);
+
+/* Return the timestamp of the most recent PSD frame, or {0,0} if none yet. */
+struct timespec lv_waterfall_get_frame_ts(lv_obj_t * obj);
+
+/* Insert a full-width marker line (scrolls like normal data). */
+void lv_waterfall_add_marker_line(lv_obj_t * obj, lv_color_t color);
 
 void lv_waterfall_set_min(lv_obj_t *obj, int16_t val);
 void lv_waterfall_set_max(lv_obj_t *obj, int16_t val);


### PR DESCRIPTION
### FT8 AutoSel (auto-pick CQ target and complete a standard FT8 QSO flow)

AutoSel acts like "clicking a CQ line on the decode list", but does it automatically: it collects CQ candidates and selects a target to call, then proceeds through the standard FT8 sequence.

Critical safety notes (please read):

- AutoSel is **only for replying to other stations' CQ** (it auto-picks from CQ candidates and calls them). It is **not** for automatically calling CQ.
- **Unattended operation is strongly discouraged**: when AutoSel is enabled, an operator must be physically present and ready to stop TX / change frequency / reduce power at any time.

Behavior highlights:

- Avoids looping on the same caller: if one station keeps CQing and a QSO attempt stalls until repeats are exhausted, AutoSel will temporarily skip that station and try others.
- "Someone calling you" has priority: while AutoSel is working, obvious to-me / to-me GRID situations can preempt the normal AutoSel flow.
- User blacklist supported:
  - Put an `autosel_blacklist.txt` file on the SD card DATA partition (one callsign per line).
  - AutoSel will always skip those callsigns, even if they are the only CQ candidates.

AutoSel mode options (on the FT8 page, button area Page 3:3; press `AutoSel` to cycle):

- Off: disable auto selection (no automatic CQ picking).
- First: pick by "first seen" order (the earliest decoded CQ within the current slot).
- Farthest: prefer the farthest CQ (requires a valid local QTH/Grid set, and a valid Grid present in the CQ info; otherwise falls back to First).
- Best SNR: prefer the best SNR CQ (higher chance to enter the flow quickly; good for reliability).
- New Grid: prefer a CQ from a "new grid" (based on your QSO log, prioritized for the current band+mode; falls back to First if no new-grid candidate exists).
  - Tip: if the list shows a `*` before a grid, it indicates "not worked yet on this band+mode".

AutoSel hard rules ("will never be selected"):

- Already-worked stations: if your QSO log contains a historical QSO for that callsign (any band/mode), AutoSel will skip it and will not call it automatically.
- User blacklist: callsigns listed in `autosel_blacklist.txt` are permanently skipped.

Note: the "never select" filtering depends on your logs and DATA partition content. If you clear/replace the log database (e.g. reset, change SD card, replace `params.db`), the historical worked filtering loses its data source.

`autosel_blacklist.txt` format: one callsign per line; lines starting with `#` or `;` are treated as comments; case/whitespace are normalized automatically.

AutoSel "temporary avoidance" (to prevent repeated re-calling):

- If AutoSel started a QSO attempt and repeats were exhausted while sending the GRID exchange message, that station is put into a short-term avoidance list.
- After several slots without decoding that station again, the short-term avoidance is cleared automatically.

Recommendation: treat AutoSel as an "assistant that clicks and drives the standard sequence", not as an "automatic station". An operator must be present.

### FT8 Auto DNF / Auto Notch

An "auto notch" logic was added for FT8:

- At the start of each time slot, it looks for very strong narrow spikes and applies a temporary narrow suppression (~70 Hz total width).
- Goal: reduce cases where a strong carrier/spur overwhelms the FT8 passband and harms decoding.
- When entering/leaving FT8, it attempts to restore your original DNF settings to avoid affecting non-FT8 use.

### FT8 Free MSG (FT8 Free Text / Type00-style one-shot custom text)

On the FT8 page, button area Page 2:3. Press `Free MSG` to enter a custom "free text" message, which will be transmitted once in the next TX slot.

- Typical use: short custom content such as `TU 73`, `PSE QSY`, `QSO B4`, etc.
- Limits (these are protocol limits of FT8 Free Text):
  - Max 13 characters.
  - Allowed character set: space, digits, A-Z, and `+-./?`.
  - The system uppercases input, filters unsupported characters, and trims leading/trailing spaces.
- Behavior:
  - If a QSO is currently active, or TX is busy, Free MSG is rejected (to avoid breaking the main flow).
  - This is a one-shot TX (repeats=1). If CQ was enabled before and there is no QSO, CQ scheduling will resume after the Free MSG TX.
  - The message is saved to `/mnt/ft8_freetext.txt` and will be shown as the default next time.

### FT8 stability and CPU drop

- Multiple fixes in the FT8 dialog behavior (audio resource contention, state transitions, waterfall edge cases, etc.) to reduce rare failures and improve long-run stability.
- Slow down main waterfall after enter FT8. Maintainer measured FT8 scenario CPU usage roughly from 29% down to 9% (~70% reduction; results may vary with settings and hardware).
- Lower CPU activity can also help reduce "digital noise" coupling into the receive noise floor (often more noticeable in weak-signal / higher-gain situations).