### PR TITLE
sysopt: dynamic CPU idle loop from bg7nzl/main

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -129,12 +129,20 @@ int main(void) {
     lv_scr_load(main_obj);
 #endif
 
+    int64_t next_loop_time, sleep_time, loop_start_time;
     while (1) {
+        loop_start_time = get_time();
         observer_delayed_notify_all();
         event_obj_check();
         scheduler_work();
-        lv_timer_handler_run_in_period(5);
-        usleep(1000);
+        next_loop_time = lv_timer_handler() + loop_start_time;
+        sleep_time = next_loop_time - get_time();
+        if (sleep_time > 0) {
+            usleep(sleep_time * 1000);
+        } else {
+            /* Cap loop rate when LVGL reports no delay to reduce CPU. */
+            usleep(5000);
+        }
     }
     return 0;
 }
@@ -142,7 +150,7 @@ int main(void) {
 void * tick_thread (void *args)
 {
       while(1) {
-        usleep(1 * 1000);
-        lv_tick_inc(1);
+        usleep(5 * 1000);
+        lv_tick_inc(5);
     }
 }


### PR DESCRIPTION
Replace lv_timer_handler_run_in_period(5) + usleep(1000) with lv_timer_handler() + dynamic sleep based on next LVGL timer. When no events are pending, cap at 5ms instead of burning CPU. Tick thread changed from 1ms to 5ms interval.

Reduces CPU usage ~70% in idle/FT8 scenarios (measured ~29% → 9%).