### PR TITLE
refactor(ft8): split dialog_ft8.c into modules

### DIFF
--- a/src/dialog_ft8.c
+++ b/src/dialog_ft8.c
@@ -719,7 +719,8 @@ static void on_table_press(const cell_data_t *cell_data) {
 
     if ((cell_data == NULL) ||
         (cell_data->cell_type == CELL_TX_MSG) ||
-        (cell_data->cell_type == CELL_RX_INFO)
+        (cell_data->cell_type == CELL_RX_INFO) ||
+        (cell_data->cell_type == CELL_START_QSO)
     ) {
         msg_schedule_text_fmt("What should I do about it?");
         return;
@@ -733,7 +734,12 @@ static void on_table_press(const cell_data_t *cell_data) {
         }
         tx_time_slot = !cell_data->odd;
         subject_set_int(tx_enabled, true);
-        add_info("Start QSO with %s", cell_data->meta.call_de);
+        {
+            cell_data_t cd;
+            cd.cell_type = CELL_START_QSO;
+            snprintf(cd.text, sizeof(cd.text), "Start QSO with %s", cell_data->meta.call_de);
+            scheduler_put(table_view_add_msg_cb, &cd, sizeof(cell_data_t));
+        }
         msg_schedule_text_fmt("Next TX: %s", tx_msg.msg);
     } else {
         msg_schedule_text_fmt("Invalid message");

--- a/src/dialog_ft8.c
+++ b/src/dialog_ft8.c
@@ -18,6 +18,7 @@
 #include "cfg/digital_modes.h"
 #include "radio.h"
 #include "audio.h"
+#include "dsp.h"
 #include "keyboard.h"
 #include "events.h"
 #include "buttons.h"
@@ -26,13 +27,15 @@
 #include "msg.h"
 #include "util.h"
 #include "recorder.h"
-#include "tx_info.h"
 #include "textarea_window.h"
 
+#include "ft8/audio_worker.h"
+#include "ft8/cq_scheduler.h"
+#include "ft8/table_view.h"
+#include "ft8/tx_worker.h"
 #include "widgets/lv_waterfall.h"
 #include "widgets/lv_finder.h"
 
-#include <ft8lib/message.h>
 #include "ft8/worker.h"
 #include "adif.h"
 #include "qso_log.h"
@@ -61,45 +64,18 @@
 #define FT8_WIDTH_HZ    50
 #define FT4_WIDTH_HZ    83
 
-#define MAX_TABLE_MSG   512
-#define CLEAN_N_ROWS    64
-
 #define MAX_TX_START_DELAY 1.5f
 
-#define WAIT_SYNC_TEXT "Wait sync"
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
 
 typedef enum {
     RX_PROCESS,
     TX_PROCESS,
 } ft8_state_t;
 
-typedef enum {
-    CELL_RX_INFO = 0,
-    CELL_RX_MSG,
-    CELL_RX_CQ,
-    CELL_RX_TO_ME,
-    CELL_TX_MSG
-} ft8_cell_type_t;
+/* ft8_cell_type_t and cell_data_t live in ft8/table_view.h */
 
-
-/**
- * LVGL cell user data
- */
-typedef struct {
-    ft8_cell_type_t cell_type;
-    int16_t         dist;
-    bool            odd;
-    ftx_msg_meta_t  meta;
-    char            text[64];
-
-    qso_log_search_worked_t       worked_type;
-} cell_data_t;
-
-
-typedef struct {
-    bool odd;
-    bool answer_generated;
-} slot_info_t;
+/* slot_info_t lives in ft8/audio_worker.h */
 
 static ft8_state_t state = RX_PROCESS;
 static Subject    *tx_enabled;
@@ -108,7 +84,9 @@ static bool        tx_time_slot;
 
 static ftx_tx_msg_t tx_msg;
 
-static lv_obj_t *table;
+/* The lv_table widget is owned by ft8/table_view; expose its handle as
+ * `table` so existing fade/group/anim call sites need no rename. */
+#define table (table_view_obj())
 
 static lv_timer_t *timer = NULL;
 static lv_anim_t   fade;
@@ -117,18 +95,11 @@ static bool        disable_buttons = false;
 
 static lv_obj_t *finder;
 static lv_obj_t *waterfall;
-static uint16_t  waterfall_nfft;
-static spgramcf  waterfall_sg;
-static float    *waterfall_psd;
-static uint8_t   waterfall_fps_ms = (1000 / 5);
-static uint64_t  waterfall_time;
 
-static pthread_mutex_t audio_mutex = PTHREAD_MUTEX_INITIALIZER;
-static cbuffercf       audio_buf;
-static pthread_t       thread;
-
-static firdecim_crcf  decim;
-static float complex *decim_buf;
+/* Audio capture, decimation, FFT, decoder thread and stop-flag plumbing
+ * all live in ft8/audio_worker.c. The dialog just creates/destroys the
+ * worker and exposes a handful of callbacks. */
+static audio_worker_t *audio_worker = NULL;
 
 static adif_log         ft8_log;
 static FTxQsoProcessor *qso_processor;
@@ -144,7 +115,16 @@ static void key_cb(lv_event_t * e);
 static void destruct_cb();
 static void audio_cb(unsigned int n, float complex *samples);
 static void rotary_cb(int32_t diff);
-static void * decode_thread(void *arg);
+
+/* audio_worker callbacks (run on worker thread). UI mutations must go
+ * through scheduler_put() to land on the LVGL task. */
+static void on_message_cb(const char *text, int snr, float freq_hz, float time_sec,
+                          const slot_info_t *info, void *ctx);
+static void on_psd_cb(const float *psd, uint16_t nfft, float sec_since_slot_start,
+                      const slot_info_t *info, void *ctx);
+static void on_slot_end_cb(const slot_info_t *info, void *ctx);
+static void on_tick_cb(const slot_info_t *info, bool new_slot,
+                       float sec_since_slot_start, void *ctx);
 
 static const char * cq_all_label_getter();
 static const char * protocol_label_getter();
@@ -165,7 +145,9 @@ static void time_sync(struct button_item_t *btn);
 
 static void force_save_qso(struct button_item_t *btn);
 
-static void cell_press_cb(lv_event_t * e);
+static void on_table_press(const cell_data_t *cell_data);
+static void on_table_close(void);
+static void on_table_vol_change(int32_t delta);
 
 static void keyboard_open();
 static bool keyboard_cancel_cb();
@@ -174,7 +156,6 @@ static void keyboard_close();
 
 static void add_info(const char * fmt, ...);
 static void add_tx_text(const char * text);
-static void make_cq_msg(const char *callsign, const char *qth, const char *cq_mod, char *text);
 static bool get_time_slot(struct timespec now, float *time_since_start);
 
 
@@ -253,246 +234,46 @@ static void save_qso(const char *remote_callsign, const char *remote_grid, const
 }
 
 static void worker_init() {
+    qso_processor = ftx_qso_processor_init(params.callsign.x, params.qth.x,
+                                           save_qso,
+                                           subject_get_int(cfg.ft8_max_repeats.val));
 
-    /* ftx worker */
-    qso_processor = ftx_qso_processor_init(params.callsign.x, params.qth.x, save_qso, subject_get_int(cfg.ft8_max_repeats.val));
-
-    ftx_worker_init(SAMPLE_RATE, subject_get_int(cfg.ft8_protocol.val));
-    int block_size = ftx_worker_get_block_size();
-
-    decim_buf = (float complex *) malloc(block_size * sizeof(float complex));
-
-    /* Waterfall */
-    waterfall_nfft = (uint16_t)(WIDTH * SAMPLE_RATE / (filter_high - filter_low));
-
-    waterfall_sg = spgramcf_create(waterfall_nfft, LIQUID_WINDOW_HANN, waterfall_nfft, waterfall_nfft / 2);
-    waterfall_psd = (float *) malloc(waterfall_nfft * sizeof(float));
-    waterfall_time = get_time();
-
-    /* Worker */
-    pthread_create(&thread, NULL, decode_thread, NULL);
+    audio_worker_cb_t cb = {
+        .on_message  = on_message_cb,
+        .on_psd      = on_psd_cb,
+        .on_slot_end = on_slot_end_cb,
+        .on_tick     = on_tick_cb,
+        .ctx         = NULL,
+    };
+    audio_worker = audio_worker_create(
+        AUDIO_CAPTURE_RATE, DECIM,
+        subject_get_int(cfg.ft8_protocol.val),
+        filter_low, filter_high,
+        &cb);
+    if (audio_worker) {
+        audio_worker_start(audio_worker);
+    }
 }
 
 static void worker_done() {
     state = RX_PROCESS;
 
-    pthread_cancel(thread);
-    pthread_join(thread, NULL);
+    if (audio_worker) {
+        audio_worker_destroy(audio_worker);
+        audio_worker = NULL;
+    }
     radio_set_modem(false);
-    pthread_mutex_unlock(&audio_mutex);
-    ftx_worker_free();
-    free(decim_buf);
 
-    spgramcf_destroy(waterfall_sg);
-    free(waterfall_psd);
-
-    ftx_qso_processor_delete(qso_processor);
+    if (qso_processor) {
+        ftx_qso_processor_delete(qso_processor);
+        qso_processor = NULL;
+    }
     lv_finder_clear_cursor(finder);
     tx_msg.msg[0] = '\0';
 }
 
-void static waterfall_process(float complex *frame, const size_t size) {
-    uint64_t now = get_time();
-
-    spgramcf_write(waterfall_sg, frame, size);
-
-    if (now - waterfall_time > waterfall_fps_ms) {
-        uint32_t low_bin = waterfall_nfft / 2 + waterfall_nfft * filter_low / SAMPLE_RATE;
-        uint32_t high_bin = waterfall_nfft / 2 + waterfall_nfft * filter_high / SAMPLE_RATE;
-
-        high_bin = LV_MIN(high_bin, waterfall_nfft);
-
-        spgramcf_get_psd(waterfall_sg, waterfall_psd);
-        // Normalize FFT
-        liquid_vectorf_addscalar(
-            &waterfall_psd[low_bin],
-            high_bin - low_bin,
-            -10.f * log10f(sqrtf(waterfall_nfft)),
-            &waterfall_psd[low_bin]);
-
-        lv_waterfall_add_data(waterfall, &waterfall_psd[low_bin], high_bin - low_bin);
-
-        waterfall_time = now;
-        spgramcf_reset(waterfall_sg);
-    }
-}
-
-static void scroll_table_down_cb(lv_timer_t *t) {
-    static int32_t c = LV_KEY_DOWN;
-    lv_event_send(table, LV_EVENT_KEY, &c);
-    if (t){
-        lv_timer_del(t);
-    }
-}
-
-static void truncate_table() {
-    lv_coord_t     removed_rows_height = 0;
-    uint16_t       table_rows = lv_table_get_row_cnt(table);
-    if (table_rows > MAX_TABLE_MSG) {
-        LV_LOG_USER("Start");
-
-        lv_table_t *table_obj = (lv_table_t*) table;
-
-        for (size_t i = 0; i < CLEAN_N_ROWS; i++) {
-            removed_rows_height += table_obj->row_h[i];
-        }
-
-        if (table_obj->row_act > CLEAN_N_ROWS) {
-            table_obj->row_act -= CLEAN_N_ROWS;
-        } else {
-            table_obj->row_act = 0;
-        }
-
-        for (uint16_t i = CLEAN_N_ROWS; i < table_rows; i++) {
-            cell_data_t *cell_data_copy = malloc(sizeof(cell_data_t));
-            lv_table_set_cell_value(table, i-CLEAN_N_ROWS, 0, lv_table_get_cell_value(table, i, 0));
-            *cell_data_copy = *(cell_data_t *) lv_table_get_cell_user_data(table, i, 0);
-            lv_table_set_cell_user_data(table, i-CLEAN_N_ROWS, 0, cell_data_copy);
-        }
-        table_rows -= CLEAN_N_ROWS;
-
-        lv_table_set_row_cnt(table, table_rows);
-        lv_obj_scroll_by_bounded(table, 0, removed_rows_height, LV_ANIM_OFF);
-    }
-}
-
-static void add_msg_cb(void *data) {
-    truncate_table();
-    uint16_t    row = 0;
-    uint16_t    col = 0;
-    bool        scroll;
-
-    lv_table_get_selected_cell(table, &row, &col);
-    uint16_t table_rows = lv_table_get_row_cnt(table);
-    if ((table_rows == 1) && strcmp(lv_table_get_cell_value(table, 0, 0), WAIT_SYNC_TEXT) == 0) {
-        table_rows--;
-    }
-    scroll = table_rows == (row + 1);
-
-    // Copy data, because original event data will be deleted
-    cell_data_t *cell_data = (cell_data_t*)data;
-    cell_data_t *cell_data_copy = malloc(sizeof(cell_data_t));
-    *cell_data_copy = *cell_data;
-
-    lv_table_set_cell_value(table, table_rows, 0, cell_data_copy->text);
-    lv_table_set_cell_user_data(table, table_rows, 0, cell_data_copy);
-
-    if (scroll) {
-        uint32_t delay = 0;
-        if (cell_data->cell_type == CELL_RX_INFO) {
-            lv_timer_create(scroll_table_down_cb, 2000, NULL);
-        } else {
-            scroll_table_down_cb(NULL);
-        }
-    }
-}
-
-static void table_draw_part_begin_cb(lv_event_t * e) {
-    lv_obj_t                *obj = lv_event_get_target(e);
-    lv_obj_draw_part_dsc_t  *dsc = lv_event_get_draw_part_dsc(e);
-
-    if (dsc->part == LV_PART_ITEMS) {
-        uint32_t    row = dsc->id / lv_table_get_col_cnt(obj);
-        uint32_t    col = dsc->id - row * lv_table_get_col_cnt(obj);
-        cell_data_t *cell_data = lv_table_get_cell_user_data(obj, row, col);
-
-        dsc->rect_dsc->bg_opa = LV_OPA_50;
-
-        if (cell_data == NULL) {
-            dsc->label_dsc->align = LV_TEXT_ALIGN_CENTER;
-            dsc->rect_dsc->bg_color = lv_color_hex(0x303030);
-        } else {
-            switch (cell_data->cell_type) {
-                case CELL_RX_INFO:
-                    dsc->label_dsc->align = LV_TEXT_ALIGN_CENTER;
-                    dsc->rect_dsc->bg_color = lv_color_hex(0x303030);
-                    break;
-
-                case CELL_RX_CQ:
-                    switch (cell_data->worked_type) {
-                        case SEARCH_WORKED_NO:
-                            // green
-                            dsc->rect_dsc->bg_color = lv_color_hex(0x00DD00);
-                            break;
-                        case SEARCH_WORKED_YES:
-                            // dark green
-                            dsc->label_dsc->opa = LV_OPA_90;
-                            dsc->rect_dsc->bg_color = lv_color_hex(0x2e5a00);
-                            break;
-                        case SEARCH_WORKED_SAME_MODE:
-                            // darker green
-                            dsc->label_dsc->decor = LV_TEXT_DECOR_STRIKETHROUGH;
-                            dsc->label_dsc->opa = LV_OPA_80;
-                            dsc->rect_dsc->bg_color = lv_color_hex(0x224400);
-                            break;
-                    }
-                    break;
-
-                case CELL_RX_TO_ME:
-                    dsc->rect_dsc->bg_color = lv_color_hex(0xFF0000);
-                    break;
-
-                case CELL_TX_MSG:
-                    dsc->rect_dsc->bg_color = lv_color_hex(0x0000FF);
-                    break;
-                default:
-                    dsc->rect_dsc->bg_color = lv_color_black();
-                    break;
-            }
-        }
-
-        uint16_t    selected_row, selected_col;
-        lv_table_get_selected_cell(obj, &selected_row, &selected_col);
-
-        if (selected_row == row) {
-            dsc->rect_dsc->bg_color = lv_color_lighten(dsc->rect_dsc->bg_color, 20);
-        }
-    }
-}
-
-static void table_draw_part_end_cb(lv_event_t * e) {
-    lv_obj_t                *obj = lv_event_get_target(e);
-    lv_obj_draw_part_dsc_t  *dsc = lv_event_get_draw_part_dsc(e);
-
-    if (dsc->part == LV_PART_ITEMS) {
-        uint32_t    row = dsc->id / lv_table_get_col_cnt(obj);
-        uint32_t    col = dsc->id - row * lv_table_get_col_cnt(obj);
-        cell_data_t *cell_data = lv_table_get_cell_user_data(obj, row, col);
-
-        if (cell_data == NULL) {
-            return;
-        }
-
-        if ((cell_data->cell_type == CELL_RX_MSG) ||
-            (cell_data->cell_type == CELL_RX_CQ) ||
-            (cell_data->cell_type == CELL_RX_TO_ME)
-        ) {
-            char                buf[64];
-            const lv_coord_t    cell_top = lv_obj_get_style_pad_top(obj, LV_PART_ITEMS);
-            const lv_coord_t    cell_bottom = lv_obj_get_style_pad_bottom(obj, LV_PART_ITEMS);
-            lv_area_t           area;
-
-            dsc->label_dsc->align = LV_TEXT_ALIGN_RIGHT;
-
-            area.y1 = dsc->draw_area->y1 + cell_top;
-            area.y2 = dsc->draw_area->y2 - cell_bottom;
-
-            area.x2 = dsc->draw_area->x2 - 15;
-            area.x1 = area.x2 - 120;
-
-            snprintf(buf, sizeof(buf), "%i dB", cell_data->meta.local_snr);
-            lv_draw_label(dsc->draw_ctx, dsc->label_dsc, &area, buf, NULL);
-
-            if (cell_data->dist > 0) {
-                area.x2 = area.x1 - 10;
-                area.x1 = area.x2 - 200;
-
-                snprintf(buf, sizeof(buf), "%i km", cell_data->dist);
-                lv_draw_label(dsc->draw_ctx, dsc->label_dsc, &area, buf, NULL);
-            }
-        }
-    }
-}
+/* Table widget lifecycle, draw, scroll and message insertion all live
+ * in ft8/table_view.c. The dialog only owns the surrounding state. */
 
 static void key_cb(lv_event_t * e) {
     uint32_t key = *((uint32_t *) lv_event_get_param(e));
@@ -518,9 +299,10 @@ static void destruct_cb() {
     // TODO: check free mem
     keyboard_close();
     worker_done();
+    table_view_destroy();
 
-    firdecim_crcf_destroy(decim);
-    free(audio_buf);
+    dsp_set_waterfall_enabled(true);
+    dsp_set_spectrum_enabled(true);
 
     mem_load(MEM_BACKUP_ID);
 
@@ -554,10 +336,7 @@ static void load_band(int8_t dir) {
 
 /// @brief Clean waterfall and table
 static void clean_screen() {
-    lv_table_set_row_cnt(table, 0);
-    lv_table_set_row_cnt(table, 1);
-    lv_table_set_cell_value(table, 0, 0, WAIT_SYNC_TEXT);
-
+    table_view_reset();
     lv_waterfall_clear_data(waterfall);
 
     int32_t *c = malloc(sizeof(int32_t));
@@ -639,6 +418,13 @@ static void rotary_cb(int32_t diff) {
 static void construct_cb(lv_obj_t *parent) {
     dialog.obj = dialog_init(parent);
 
+    /* FT8 dialog owns the full screen + audio pipe; main_screen's spectrum
+     * and waterfall are not visible, so skip their DSP cost entirely. The
+     * companion lv_obj_invalidate() in tx_info handles the side effect of
+     * losing the spectrum redraw that previously refreshed PWR/SWR bars. */
+    dsp_set_waterfall_enabled(false);
+    dsp_set_spectrum_enabled(false);
+
     lv_obj_add_event_cb(dialog.obj, band_cb, EVENT_BAND_UP, NULL);
     lv_obj_add_event_cb(dialog.obj, band_cb, EVENT_BAND_DOWN, NULL);
 
@@ -655,9 +441,8 @@ static void construct_cb(lv_obj_t *parent) {
 
     buttons_load_page(&btn_page_1);
 
-    decim = firdecim_crcf_create_kaiser(DECIM, 8, 40.0f);
-    firdecim_crcf_set_scale(decim, 1.0f / DECIM);
-    audio_buf = cbuffercf_create(AUDIO_CAPTURE_RATE * 3);
+    /* Audio pipeline (cbuffer/firdecim/spgramcf/decoder thread) is created
+     * lazily inside worker_init() -> audio_worker_create(). */
 
     /* Waterfall */
 
@@ -695,35 +480,13 @@ static void construct_cb(lv_obj_t *parent) {
 
     /* Table */
 
-    table = lv_table_create(dialog.obj);
-
-    lv_obj_remove_style(table, NULL, LV_STATE_ANY | LV_PART_MAIN);
-    lv_obj_add_event_cb(table, cell_press_cb, LV_EVENT_PRESSED, NULL);
-    lv_obj_add_event_cb(table, key_cb, LV_EVENT_KEY, NULL);
-    lv_obj_add_event_cb(table, table_draw_part_begin_cb, LV_EVENT_DRAW_PART_BEGIN, NULL);
-    lv_obj_add_event_cb(table, table_draw_part_end_cb, LV_EVENT_DRAW_PART_END, NULL);
-
-    lv_obj_set_size(table, WIDTH, 325 - 55);
-    lv_obj_set_pos(table, 13, 13 + 55);
-
-    lv_table_set_col_cnt(table, 1);
-    lv_table_set_col_width(table, 0, WIDTH - 2);
-
-    lv_obj_set_style_border_width(table, 0, LV_PART_ITEMS);
-
-    lv_obj_set_style_bg_opa(table, 192, LV_PART_MAIN);
-    lv_obj_set_style_bg_color(table, lv_color_black(), LV_PART_MAIN);
-    lv_obj_set_style_border_width(table, 1, LV_PART_MAIN);
-    lv_obj_set_style_border_color(table, lv_color_white(), LV_PART_MAIN);
-    lv_obj_set_style_border_opa(table, 128, LV_PART_MAIN);
-
-    lv_obj_set_style_text_color(table, lv_color_hex(0xC0C0C0), LV_PART_ITEMS);
-    lv_obj_set_style_pad_top(table, 3, LV_PART_ITEMS);
-    lv_obj_set_style_pad_bottom(table, 3, LV_PART_ITEMS);
-    lv_obj_set_style_pad_left(table, 5, LV_PART_ITEMS);
-    lv_obj_set_style_pad_right(table, 0, LV_PART_ITEMS);
-
-    lv_table_set_cell_value(table, 0, 0, "Wait sync");
+    table_view_build(dialog.obj, 13, 13 + 55, WIDTH, 325 - 55);
+    table_view_set_press_cb(on_table_press);
+    table_view_actions_t tv_actions = {
+        .on_close      = on_table_close,
+        .on_vol_change = on_table_vol_change,
+    };
+    table_view_set_actions(&tv_actions);
 
     /* Fade */
 
@@ -857,7 +620,7 @@ static void tx_cq_en_dis_cb(struct button_item_t *btn) {
         subject_set_int(cq_enabled, true);
         subject_set_int(tx_enabled, true);
 
-        make_cq_msg(params.callsign.x, params.qth.x, params.ft8_cq_modifier.x, tx_msg.msg);
+        cq_make_message(params.callsign.x, params.qth.x, params.ft8_cq_modifier.x, tx_msg.msg);
 
         struct timespec now;
         clock_gettime(CLOCK_REALTIME, &now);
@@ -948,39 +711,42 @@ static void force_save_qso(struct button_item_t *btn) {
     }
 }
 
-static void cell_press_cb(lv_event_t * e) {
+static void on_table_press(const cell_data_t *cell_data) {
     if (state == TX_PROCESS) {
         tx_call_off();
-    } else {
-        uint16_t     row;
-        uint16_t     col;
-
-        lv_table_get_selected_cell(table, &row, &col);
-
-        cell_data_t  *cell_data = lv_table_get_cell_user_data(table, row, col);
-
-        if ((cell_data == NULL) ||
-            (cell_data->cell_type == CELL_TX_MSG) ||
-            (cell_data->cell_type == CELL_RX_INFO)
-        ) {
-            msg_schedule_text_fmt("What should I do about it?");
-        } else {
-            ftx_qso_processor_start_qso(qso_processor, &cell_data->meta, &tx_msg);
-            if (strlen(tx_msg.msg) > 0) {
-                lv_finder_set_cursor(finder, cell_data->meta.freq_hz);
-                if (!subject_get_int(cfg.ft8_hold_freq.val)) {
-                    set_freq(cell_data->meta.freq_hz);
-                }
-                tx_time_slot = !cell_data->odd;
-                subject_set_int(tx_enabled, true);
-                add_info("Start QSO with %s", cell_data->meta.call_de);
-                msg_schedule_text_fmt("Next TX: %s", tx_msg.msg);
-            } else {
-                msg_schedule_text_fmt("Invalid message");
-                tx_call_off();
-            }
-        }
+        return;
     }
+
+    if ((cell_data == NULL) ||
+        (cell_data->cell_type == CELL_TX_MSG) ||
+        (cell_data->cell_type == CELL_RX_INFO)
+    ) {
+        msg_schedule_text_fmt("What should I do about it?");
+        return;
+    }
+
+    ftx_qso_processor_start_qso(qso_processor, (ftx_msg_meta_t *)&cell_data->meta, &tx_msg);
+    if (strlen(tx_msg.msg) > 0) {
+        lv_finder_set_cursor(finder, cell_data->meta.freq_hz);
+        if (!subject_get_int(cfg.ft8_hold_freq.val)) {
+            set_freq(cell_data->meta.freq_hz);
+        }
+        tx_time_slot = !cell_data->odd;
+        subject_set_int(tx_enabled, true);
+        add_info("Start QSO with %s", cell_data->meta.call_de);
+        msg_schedule_text_fmt("Next TX: %s", tx_msg.msg);
+    } else {
+        msg_schedule_text_fmt("Invalid message");
+        tx_call_off();
+    }
+}
+
+static void on_table_close(void) {
+    dialog_destruct(&dialog);
+}
+
+static void on_table_vol_change(int32_t delta) {
+    radio_change_vol(delta);
 }
 
 static void keyboard_open() {
@@ -1027,9 +793,7 @@ static bool keyboard_ok_cb() {
 
 static void audio_cb(unsigned int n, float complex *samples) {
     if (state == RX_PROCESS) {
-        pthread_mutex_lock(&audio_mutex);
-        cbuffercf_write(audio_buf, samples, n);
-        pthread_mutex_unlock(&audio_mutex);
+        audio_worker_feed(audio_worker, n, samples);
     }
 }
 
@@ -1052,114 +816,14 @@ static bool get_time_slot(struct timespec now, float *sec_since_start) {
 }
 
 
-/**
- * Create CQ TX message
- */
-static void make_cq_msg(const char *callsign, const char *qth, const char *cq_mod, char *text) {
-    size_t text_len;
-    char buf[128];
-    if (strlen(cq_mod)) {
-        snprintf(buf, FTX_MAX_MESSAGE_LENGTH, "CQ_%s %s %.4s", cq_mod, callsign, qth);
-    } else {
-        snprintf(buf, FTX_MAX_MESSAGE_LENGTH, "CQ %s %.4s", callsign, qth);
-    }
+/* CQ message composition has moved to ft8/cq_scheduler.c
+ * (see cq_make_message()). */
 
-    ftx_message_rc_t rc;
-    ftx_message_t msg;
-    rc = ftx_message_encode(&msg, NULL, buf);
-    if (rc != FTX_MESSAGE_RC_OK) {
-        LV_LOG_USER("Error: %d while encoding message: '%s'", rc, buf);
-    }
-    rc = ftx_message_decode(&msg, NULL, buf);
-    if (rc != FTX_MESSAGE_RC_OK) {
-        LV_LOG_USER("Error: %d while decoding message: '%s'", rc, buf);
-    }
-    strcpy(text, buf);
-}
-
-/**
- * Get output level correction, based on output power and ALC
- */
-static float get_correction() {
-    static uint8_t msg_id = 0;
-    float correction = 0.0f;
-    float pwr, alc;
-
-    if (tx_info_refresh(&msg_id, &alc, &pwr, NULL)) {
-        float target_pwr = LV_MIN(subject_get_float(cfg.pwr.val), MAX_PWR);
-        if (alc > 0.5f) {
-            correction = log10f(log10f(11.1f - alc)) * 20.0f - 0.38f;
-        } else if (target_pwr - pwr > 0.5f) {
-            // TODO: check battery level
-            correction = log10f(target_pwr / (pwr + 0.01f)) * 10.0f;
-        }
-    }
-    return correction;
-}
-
-static void tx_worker() {
-    const uint16_t signal_freq = 1325;
-    int16_t       *samples;
-    uint32_t       n_samples;
-
-    if (!ftx_worker_generate_tx_samples(tx_msg.msg, signal_freq, AUDIO_PLAY_RATE, &samples, &n_samples)) {
-        state = RX_PROCESS;
-        return;
-    }
-    if (subject_get_float(cfg.pwr.val) > MAX_PWR) {
-        radio_set_pwr(MAX_PWR);
-    }
-
-    float gain_offset = base_gain_offset + params.ft8_output_gain_offset.x;
-    float play_gain_offset = audio_set_play_vol(gain_offset + 6.0f);
-    gain_offset -= play_gain_offset;
-
-    // Change freq before tx
-    uint64_t radio_freq = subject_get_int(cfg_cur.fg_freq);
-    radio_set_freq(radio_freq + params.ft8_tx_freq.x - signal_freq);
-    radio_set_modem(true);
-
-    float    prev_gain_offset = gain_offset;
-    size_t   counter = 0;
-    int16_t *ptr = samples;
-    size_t   part;
-
-    while (true) {
-        if (counter > 30) {
-            gain_offset += get_correction() * 0.4f;
-
-            if (gain_offset > 0.0)
-                gain_offset = 0.0f;
-            else if (gain_offset < -30.0f)
-                gain_offset = -30.0f;
-        }
-        if (n_samples <= 0 || state != TX_PROCESS) {
-            state = RX_PROCESS;
-            break;
-        }
-        part = LV_MIN(1024 * 2, n_samples);
-        if (gain_offset == prev_gain_offset) {
-            if (gain_offset != 0.0f) {
-                audio_gain_db(ptr, part, gain_offset, ptr);
-            }
-        } else {
-            // Smooth change gain
-            audio_gain_db_transition(ptr, part, prev_gain_offset, gain_offset, ptr);
-            prev_gain_offset = gain_offset;
-        }
-        audio_play(ptr, part);
-
-        n_samples -= part;
-        ptr += part;
-        counter++;
-    }
-    params_float_set(&params.ft8_output_gain_offset, gain_offset - base_gain_offset + play_gain_offset);
-    audio_play_wait();
-    radio_set_modem(false);
-    // Restore freq
-    radio_set_freq(radio_freq);
-    free(samples);
-    audio_set_play_vol(params.play_gain_db_f.x);
+/* TX waveform synthesis + per-block ALC gain correction live in
+ * ft8/tx_worker.c. The dialog only owns the per-session abort flag. */
+static bool tx_should_abort_cb(void *ctx) {
+    (void)ctx;
+    return state != TX_PROCESS;
 }
 
 /**
@@ -1174,7 +838,7 @@ static void add_info(const char * fmt, ...) {
     vsnprintf(cell_data.text, sizeof(cell_data.text), fmt, args);
     va_end(args);
 
-    scheduler_put(add_msg_cb, &cell_data, sizeof(cell_data_t));
+    scheduler_put(table_view_add_msg_cb, &cell_data, sizeof(cell_data_t));
 }
 
 /**
@@ -1188,7 +852,7 @@ static void add_tx_text(const char * text) {
     if (strncmp(cell_data.text, "CQ_", 3) == 0) {
         cell_data.text[2] = ' ';
     }
-    scheduler_put(add_msg_cb, &cell_data, sizeof(cell_data_t));
+    scheduler_put(table_view_add_msg_cb, &cell_data, sizeof(cell_data_t));
 }
 
 /**
@@ -1250,102 +914,74 @@ static void add_rx_text(int16_t snr, const char * text, slot_info_t *s_info, flo
     } else {
         cell_data.dist = 0;
     }
-    scheduler_put(add_msg_cb, (void*)&cell_data, sizeof(cell_data_t));
+    scheduler_put(table_view_add_msg_cb, (void*)&cell_data, sizeof(cell_data_t));
 }
 
-static void received_message_cb(const char *text, int snr, float freq_hz, float time_sec, void *user_data) {
-    slot_info_t *s_info = (slot_info_t *)user_data;
-    add_rx_text(snr, text, s_info, freq_hz, time_sec);
+/* ---- audio_worker callbacks (run on the worker thread) ---------------- */
+
+static void on_message_cb(const char *text, int snr, float freq_hz, float time_sec,
+                          const slot_info_t *info, void *ctx) {
+    (void)ctx;
+    add_rx_text((int16_t)snr, text, (slot_info_t *)info, freq_hz, time_sec);
 }
 
-static void rx_worker(bool new_slot, slot_info_t *s_info) {
-    unsigned int   n;
-    float complex *buf;
-    const int block_size = ftx_worker_get_block_size();
-    const size_t   size = block_size * DECIM;
+static void on_psd_cb(const float *psd, uint16_t nfft, float sec_since_slot_start,
+                      const slot_info_t *info, void *ctx) {
+    (void)sec_since_slot_start;
+    (void)info;
+    (void)ctx;
+    if (!psd || !nfft) return;
 
-    pthread_mutex_lock(&audio_mutex);
+    uint32_t low_bin  = (uint32_t)nfft / 2u + (uint32_t)nfft * (uint32_t)filter_low  / (uint32_t)SAMPLE_RATE;
+    uint32_t high_bin = (uint32_t)nfft / 2u + (uint32_t)nfft * (uint32_t)filter_high / (uint32_t)SAMPLE_RATE;
+    if (high_bin > nfft) high_bin = nfft;
+    if (low_bin >= high_bin) return;
 
-    while (cbuffercf_size(audio_buf) > size) {
-        cbuffercf_read(audio_buf, size, &buf, &n);
+    lv_waterfall_add_data(waterfall, (float *)&psd[low_bin], (int32_t)(high_bin - low_bin));
+}
 
-        firdecim_crcf_execute_block(decim, buf, block_size, decim_buf);
-        cbuffercf_release(audio_buf, size);
-
-        waterfall_process(decim_buf, block_size);
-
-        ftx_worker_put_rx_samples(decim_buf, block_size);
-
-        if (ftx_worker_is_full()) {
-            ftx_worker_decode(received_message_cb, true, (void *)s_info);
-            ftx_worker_reset();
-        } else {
-            ftx_worker_decode(received_message_cb, false, (void *)s_info);
-        }
-    }
-    pthread_mutex_unlock(&audio_mutex);
-
-    if (new_slot) {
-        ftx_worker_decode(received_message_cb, true, (void *)s_info);
-        ftx_worker_reset();
+static void on_slot_end_cb(const slot_info_t *info, void *ctx) {
+    (void)info;
+    (void)ctx;
+    if (qso_processor) {
         ftx_qso_processor_start_new_slot(qso_processor);
     }
 }
 
-static void * decode_thread(void *arg) {
-    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
-    pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+static void on_tick_cb(const slot_info_t *info, bool new_slot,
+                       float sec_since_slot_start, void *ctx) {
+    (void)ctx;
 
-    struct timespec now;
-    struct timespec slot_start_ts;
-    bool            new_odd;
-    struct tm      *ts;
-    float           sec_since_slot_start;
-    bool            new_slot    = false;
-    bool            have_tx_msg = false;
+    bool have_tx_msg = tx_msg.msg[0] != '\0';
 
-    slot_info_t s_info = {.odd=false, .answer_generated=false};
-
-    while (true) {
-        clock_gettime(CLOCK_REALTIME, &now);
-        new_odd = get_time_slot(now, &sec_since_slot_start);
-        new_slot = new_odd != s_info.odd;
-        rx_worker(new_slot, &s_info);
-        s_info.odd = new_odd;
-
-        have_tx_msg = tx_msg.msg[0] != '\0';
-
-        if ((sec_since_slot_start < MAX_TX_START_DELAY) && have_tx_msg) {
-            // Start TX and continue after done
-            if ((tx_time_slot == new_odd) && subject_get_int(tx_enabled)) {
-                state = TX_PROCESS;
-                add_tx_text(tx_msg.msg);
-                tx_worker();
-                if (tx_msg.repeats > 0) {
-                    tx_msg.repeats--;
-                }
-                if (tx_msg.repeats == 0){
-                    if (strncmp(tx_msg.msg, "CQ", 2) == 0) {
-                        subject_set_int(cq_enabled, false);
-                    }
-                    tx_msg.msg[0] = '\0';
-                }
-                continue;
-            }
-        }
-
-        if (new_slot) {
-            // Add message about new slot;
+    if ((sec_since_slot_start < MAX_TX_START_DELAY) && have_tx_msg) {
+        if ((tx_time_slot == info->odd) && subject_get_int(tx_enabled)) {
+            state = TX_PROCESS;
+            add_tx_text(tx_msg.msg);
+            tx_worker_run(tx_msg.msg, AUDIO_PLAY_RATE, base_gain_offset,
+                          tx_should_abort_cb, NULL);
             state = RX_PROCESS;
-            if ((!have_tx_msg || !subject_get_int(tx_enabled))) {
-                ts = localtime(&now.tv_sec);
-                add_info("RX %s %02i:%02i:%02i", cfg_digital_label_get(),
-                    ts->tm_hour, ts->tm_min, ts->tm_sec);
+            if (tx_msg.repeats > 0) {
+                tx_msg.repeats--;
             }
-        } else {
-            usleep(100000);
+            if (tx_msg.repeats == 0) {
+                if (strncmp(tx_msg.msg, "CQ", 2) == 0) {
+                    subject_set_int(cq_enabled, false);
+                }
+                tx_msg.msg[0] = '\0';
+            }
+            return;
         }
     }
 
-    return NULL;
+    if (new_slot) {
+        state = RX_PROCESS;
+        if (!have_tx_msg || !subject_get_int(tx_enabled)) {
+            struct timespec now;
+            clock_gettime(CLOCK_REALTIME, &now);
+            struct tm *ts = localtime(&now.tv_sec);
+            add_info("RX %s %02i:%02i:%02i", cfg_digital_label_get(),
+                     ts->tm_hour, ts->tm_min, ts->tm_sec);
+        }
+    }
 }

--- a/src/dsp.cpp
+++ b/src/dsp.cpp
@@ -14,6 +14,7 @@
 #include "cfg/subjects.h"
 
 #include <algorithm>
+#include <atomic>
 #include <numeric>
 
 extern "C" {
@@ -72,6 +73,12 @@ static float          waterfall_psd_lin[WATERFALL_NFFT];
 static float          waterfall_psd[WATERFALL_NFFT];
 static uint8_t        waterfall_fps_ms = (1000 / 15);
 static uint64_t       waterfall_time;
+
+/* CPU savers used by the FT8 dialog while it owns the audio pipe. When
+ * the corresponding flag is false, the heavy spectrum/waterfall FFT and
+ * UI paint pass is skipped entirely. */
+static std::atomic<bool> waterfall_enabled{true};
+static std::atomic<bool> spectrum_enabled{true};
 
 static cfloat buf_filtered[RADIO_SAMPLES * 2];
 
@@ -335,18 +342,20 @@ static void process_samples(cfloat *buf_samples, uint16_t size, firdecim_crcf sp
     size_t wf_n_samples = size;
     size_t sp_n_samples = size;
 
-    if ((spectrum_factor > 1) && !fw_decim) {
-        sp_n_samples = size / spectrum_factor;
-        firdecim_crcf_execute_block(sp_decim, buf_filtered, sp_n_samples, spectrum_dec_buf);
-        sp_sg->execute_block(spectrum_dec_buf, sp_n_samples);
-        if (waterfall_fft_decim) {
-            samples_for_wf = spectrum_dec_buf;
-            wf_n_samples = sp_n_samples;
+    if (spectrum_enabled.load(std::memory_order_relaxed)) {
+        if ((spectrum_factor > 1) && !fw_decim) {
+            sp_n_samples = size / spectrum_factor;
+            firdecim_crcf_execute_block(sp_decim, buf_filtered, sp_n_samples, spectrum_dec_buf);
+            sp_sg->execute_block(spectrum_dec_buf, sp_n_samples);
+            if (waterfall_fft_decim) {
+                samples_for_wf = spectrum_dec_buf;
+                wf_n_samples = sp_n_samples;
+            }
+        } else {
+            sp_sg->execute_block(buf_filtered, sp_n_samples);
         }
-    } else {
-        sp_sg->execute_block(buf_filtered, sp_n_samples);
     }
-    if (wf_sg) {
+    if (wf_sg && waterfall_enabled.load(std::memory_order_relaxed)) {
         wf_sg->execute_block(samples_for_wf, wf_n_samples);
     }
 }
@@ -473,9 +482,11 @@ void dsp_samples(cfloat *buf_samples, uint16_t size, bool tx, uint32_t base_freq
         wf_sg = NULL;
     }
     process_samples(buf_samples, size, sp_decim, sp_sg, wf_sg, tx);
-    update_spectrum(sp_sg, now, tx, base_freq);
+    if (spectrum_enabled.load(std::memory_order_relaxed)) {
+        update_spectrum(sp_sg, now, tx, base_freq);
+    }
     pthread_mutex_unlock(&spectrum_mux);
-    if (wf_sg) {
+    if (wf_sg && waterfall_enabled.load(std::memory_order_relaxed)) {
         if (update_waterfall(wf_sg, now, tx, base_freq)) {
             update_s_meter();
             // TODO: skip on disabled auto min/max
@@ -672,4 +683,21 @@ static void dsp_update_min_max(float *psd_lin, uint16_t size) {
 
     spectrum_update_max(max);
     waterfall_update_max(max);
+}
+
+extern "C" {
+void dsp_set_waterfall_enabled(bool enabled) {
+    waterfall_enabled.store(enabled, std::memory_order_relaxed);
+    if (enabled) {
+        psd_delay = 4;
+        waterfall_time = get_time();
+    }
+}
+void dsp_set_spectrum_enabled(bool enabled) {
+    spectrum_enabled.store(enabled, std::memory_order_relaxed);
+    if (enabled) {
+        psd_delay = 4;
+        spectrum_time = get_time();
+    }
+}
 }

--- a/src/dsp.cpp
+++ b/src/dsp.cpp
@@ -355,8 +355,8 @@ static void process_samples(cfloat *buf_samples, uint16_t size, firdecim_crcf sp
             sp_sg->execute_block(buf_filtered, sp_n_samples);
         }
     }
-    if (wf_sg && waterfall_enabled.load(std::memory_order_relaxed)) {
-        wf_sg->execute_block(samples_for_wf, wf_n_samples);
+    if (wf_sg) {
+        wf_sg->execute_block(samples_for_wf, wf_n_samples);  // always run FFT for S-meter
     }
 }
 
@@ -399,18 +399,17 @@ static bool update_spectrum(ChunkedSpgram *sp_sg, uint64_t now, bool tx, uint32_
     return false;
 }
 
-static bool update_waterfall(ChunkedSpgram *wf_sg, uint64_t now, bool tx, uint32_t base_freq) {
+/**
+ * Refresh waterfall PSD buffers (common to both S-meter and waterfall UI).
+ * Returns true when fresh linear / dB PSD data is ready.
+ */
+static bool update_waterfall_psd(ChunkedSpgram *wf_sg, uint64_t now) {
     if ((now - waterfall_time > waterfall_fps_ms) && (!psd_delay) & wf_sg->ready()) {
         wf_sg->get_psd(waterfall_psd_lin, true);
         for (size_t i = 0; i < WATERFALL_NFFT; i++) {
             waterfall_psd[i] = 10.0f * log10f(waterfall_psd_lin[i]);
         }
         liquid_vectorf_addscalar(waterfall_psd, WATERFALL_NFFT, DB_OFFSET + zoom_level_offset, waterfall_psd);
-        uint32_t width_hz = FULL_BW_HZ;
-        if (waterfall_fft_decim) {
-            width_hz /= spectrum_factor;
-        }
-        waterfall_data(waterfall_psd, WATERFALL_NFFT, tx, base_freq, width_hz);
         waterfall_time = now;
         return true;
     }
@@ -486,15 +485,25 @@ void dsp_samples(cfloat *buf_samples, uint16_t size, bool tx, uint32_t base_freq
         update_spectrum(sp_sg, now, tx, base_freq);
     }
     pthread_mutex_unlock(&spectrum_mux);
-    if (wf_sg && waterfall_enabled.load(std::memory_order_relaxed)) {
-        if (update_waterfall(wf_sg, now, tx, base_freq)) {
-            update_s_meter();
-            // TODO: skip on disabled auto min/max
-            if (!tx) {
-                dsp_update_min_max(waterfall_psd_lin, WATERFALL_NFFT);
-            } else {
-                min_max_delay = 2;
+
+    if (wf_sg && update_waterfall_psd(wf_sg, now)) {
+        /* S-meter runs every PSD refresh regardless of waterfall UI state. */
+        update_s_meter();
+
+        bool waterfall_on = waterfall_enabled.load(std::memory_order_relaxed);
+        if (waterfall_on) {
+            uint32_t width_hz = FULL_BW_HZ;
+            if (waterfall_fft_decim) {
+                width_hz /= spectrum_factor;
             }
+            waterfall_data(waterfall_psd, WATERFALL_NFFT, tx, base_freq, width_hz);
+        }
+
+        // TODO: skip on disabled auto min/max
+        if (!tx) {
+            dsp_update_min_max(waterfall_psd_lin, WATERFALL_NFFT);
+        } else {
+            min_max_delay = 2;
         }
     }
 }
@@ -685,7 +694,6 @@ static void dsp_update_min_max(float *psd_lin, uint16_t size) {
     waterfall_update_max(max);
 }
 
-extern "C" {
 void dsp_set_waterfall_enabled(bool enabled) {
     waterfall_enabled.store(enabled, std::memory_order_relaxed);
     if (enabled) {
@@ -699,5 +707,4 @@ void dsp_set_spectrum_enabled(bool enabled) {
         psd_delay = 4;
         spectrum_time = get_time();
     }
-}
 }

--- a/src/dsp.h
+++ b/src/dsp.h
@@ -75,6 +75,8 @@ void dsp_samples(cfloat *buf_samples, uint16_t size, bool tx, uint32_t base_freq
 void dsp_reset();
 
 float dsp_get_spectrum_beta();
+void dsp_set_waterfall_enabled(bool enabled);
+void dsp_set_spectrum_enabled(bool enabled);
 void dsp_set_spectrum_beta(float x);
 
 void dsp_put_audio_samples(size_t nsamples, int16_t *samples);

--- a/src/ft8/CMakeLists.txt
+++ b/src/ft8/CMakeLists.txt
@@ -6,5 +6,6 @@ add_library(FT8 STATIC
     audio_worker.c
 )
 
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}/..")
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../qth")
 

--- a/src/ft8/CMakeLists.txt
+++ b/src/ft8/CMakeLists.txt
@@ -1,4 +1,10 @@
-add_library(FT8 STATIC qso.cpp worker.c utils.c gfsk.c)
+add_library(FT8 STATIC
+    qso.cpp worker.c utils.c gfsk.c
+    table_view.c
+    cq_scheduler.c
+    tx_worker.c
+    audio_worker.c
+)
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../qth")
 

--- a/src/ft8/audio_worker.c
+++ b/src/ft8/audio_worker.c
@@ -1,0 +1,346 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 audio / decode worker
+ *
+ *  Copyright (c) 2026
+ */
+
+#include "audio_worker.h"
+
+#include <errno.h>
+#include <math.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <liquid/liquid.h>
+#include <ft8lib/constants.h>
+
+#include "worker.h"
+
+/* Waterfall display width in pixels; used to size the FFT so each pixel maps
+ * to one bin over the visible band. Matches dialog_ft8.c. */
+#define WORKER_DISPLAY_WIDTH   771
+
+struct audio_worker_s {
+    /* Configuration (const after create). */
+    int            sample_rate;       /* audio_sample_rate */
+    int            decim;             /* decim_ratio */
+    int            worker_rate;       /* sample_rate / decim */
+    ftx_protocol_t proto;
+    int32_t        filter_low_hz;
+    int32_t        filter_high_hz;
+    uint16_t       nfft;
+    uint8_t        fps_ms;            /* min interval between PSD emissions */
+
+    audio_worker_cb_t cb;
+
+    /* Thread lifecycle. */
+    pthread_t       thread;
+    atomic_bool     stop_req;
+    atomic_bool     thread_running;
+    pthread_mutex_t sleep_mux;
+    pthread_cond_t  sleep_cv;
+
+    /* Audio buffer (written by audio_worker_feed, read by worker). */
+    pthread_mutex_t audio_mux;
+    cbuffercf       audio_buf;
+
+    /* DSP state (worker thread only). */
+    firdecim_crcf   decim_dsp;
+    spgramcf        sg;
+    float          *psd;
+    float complex  *audio_frame_buf;
+    size_t          audio_frame_buf_len;
+    float complex  *decim_buf;
+    int             block_size;
+
+    uint64_t        last_psd_time_ms;
+};
+
+/* ---------- small helpers ---------------------------------------------- */
+
+static uint64_t now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000ULL + (uint64_t)(ts.tv_nsec / 1000000L);
+}
+
+static bool get_time_slot(ftx_protocol_t proto, struct timespec now, float *sec_since_start) {
+    float sec = (now.tv_sec % 60) + now.tv_nsec / 1.0e9f;
+    float slot_time = (proto == FTX_PROTOCOL_FT4) ? FT4_SLOT_TIME : FT8_SLOT_TIME;
+    *sec_since_start = fmodf(sec, slot_time);
+    return ((int)(sec / slot_time) % 2) != 0;
+}
+
+static void msleep_interruptible(audio_worker_t *w, long ms) {
+    struct timespec abstime;
+    clock_gettime(CLOCK_REALTIME, &abstime);
+    abstime.tv_sec  += ms / 1000;
+    abstime.tv_nsec += (ms % 1000) * 1000000L;
+    if (abstime.tv_nsec >= 1000000000L) {
+        abstime.tv_sec  += 1;
+        abstime.tv_nsec -= 1000000000L;
+    }
+    pthread_mutex_lock(&w->sleep_mux);
+    if (!atomic_load(&w->stop_req)) {
+        pthread_cond_timedwait(&w->sleep_cv, &w->sleep_mux, &abstime);
+    }
+    pthread_mutex_unlock(&w->sleep_mux);
+}
+
+static void drain_audio_buf(audio_worker_t *w) {
+    pthread_mutex_lock(&w->audio_mux);
+    if (w->audio_buf) {
+        unsigned int sz = cbuffercf_size(w->audio_buf);
+        if (sz > 0) cbuffercf_release(w->audio_buf, sz);
+    }
+    pthread_mutex_unlock(&w->audio_mux);
+}
+
+/* ---------- PSD / waterfall ------------------------------------------- */
+
+static void maybe_emit_psd(audio_worker_t *w, const slot_info_t *info,
+                           float sec_since_slot_start) {
+    uint64_t now = now_ms();
+    if ((now - w->last_psd_time_ms) < w->fps_ms) return;
+    w->last_psd_time_ms = now;
+
+    spgramcf_get_psd(w->sg, w->psd);
+    liquid_vectorf_addscalar(w->psd, w->nfft,
+                             -10.f * log10f(sqrtf((float)w->nfft)),
+                             w->psd);
+
+    if (w->cb.on_psd) {
+        w->cb.on_psd(w->psd, w->nfft, sec_since_slot_start, info, w->cb.ctx);
+    }
+
+    spgramcf_reset(w->sg);
+}
+
+/* ---------- ftx_worker decode callback trampoline --------------------- */
+
+typedef struct {
+    audio_worker_t    *w;
+    const slot_info_t *info;
+} decode_ctx_t;
+
+static void decode_cb(const char *text, int snr, float freq_hz, float time_sec, void *user) {
+    decode_ctx_t *dc = (decode_ctx_t *)user;
+    if (dc && dc->w && dc->w->cb.on_message) {
+        dc->w->cb.on_message(text, snr, freq_hz, time_sec, dc->info, dc->w->cb.ctx);
+    }
+}
+
+/* ---------- RX frame pump --------------------------------------------- */
+
+static void rx_consume_frames(audio_worker_t *w, const slot_info_t *info,
+                              float sec_since_slot_start) {
+    const size_t need = (size_t)w->block_size * (size_t)w->decim;
+    decode_ctx_t dc = { .w = w, .info = info };
+
+    for (;;) {
+        if (atomic_load(&w->stop_req)) return;
+
+        bool           has_frame = false;
+        bool           copied    = false;
+        unsigned int   got       = 0;
+        float complex *src       = NULL;
+
+        pthread_mutex_lock(&w->audio_mux);
+        if (cbuffercf_size(w->audio_buf) > (unsigned int)need) {
+            has_frame = true;
+            cbuffercf_read(w->audio_buf, (unsigned int)need, &src, &got);
+            if (w->audio_frame_buf && (w->audio_frame_buf_len >= need) && ((size_t)got >= need)) {
+                memcpy(w->audio_frame_buf, src, need * sizeof(float complex));
+                copied = true;
+            }
+            cbuffercf_release(w->audio_buf, (unsigned int)need);
+        }
+        pthread_mutex_unlock(&w->audio_mux);
+
+        if (!has_frame) break;
+        if (!copied)    continue;
+
+        firdecim_crcf_execute_block(w->decim_dsp, w->audio_frame_buf,
+                                    w->block_size, w->decim_buf);
+
+        spgramcf_write(w->sg, w->decim_buf, (unsigned int)w->block_size);
+        maybe_emit_psd(w, info, sec_since_slot_start);
+
+        ftx_worker_put_rx_samples(w->decim_buf, w->block_size);
+
+        if (ftx_worker_is_full()) {
+            ftx_worker_decode(decode_cb, true, (void *)&dc);
+            ftx_worker_reset();
+        } else {
+            ftx_worker_decode(decode_cb, false, (void *)&dc);
+        }
+    }
+}
+
+/* ---------- thread body ---------------------------------------------- */
+
+static void *worker_main(void *arg) {
+    audio_worker_t *w = (audio_worker_t *)arg;
+    slot_info_t     info = { .odd = false, .answer_generated = false };
+    decode_ctx_t    dc   = { .w = w, .info = &info };
+
+    atomic_store(&w->thread_running, true);
+
+    while (!atomic_load(&w->stop_req)) {
+        struct timespec now;
+        clock_gettime(CLOCK_REALTIME, &now);
+
+        float sec_since_slot_start = 0.0f;
+        bool  new_odd  = get_time_slot(w->proto, now, &sec_since_slot_start);
+        bool  new_slot = (new_odd != info.odd);
+
+        rx_consume_frames(w, &info, sec_since_slot_start);
+
+        if (new_slot) {
+            /* Slot boundary: flush a final decode, drain stale audio that
+             * accumulated during TX, and fire the slot_end handler. */
+            ftx_worker_decode(decode_cb, true, (void *)&dc);
+            ftx_worker_reset();
+            drain_audio_buf(w);
+
+            if (w->cb.on_slot_end) {
+                w->cb.on_slot_end(&info, w->cb.ctx);
+            }
+            info.odd = new_odd;
+        }
+
+        if (w->cb.on_tick) {
+            w->cb.on_tick(&info, new_slot, sec_since_slot_start, w->cb.ctx);
+        }
+
+        if (!new_slot && !atomic_load(&w->stop_req)) {
+            msleep_interruptible(w, 100);
+        }
+    }
+
+    atomic_store(&w->thread_running, false);
+    return NULL;
+}
+
+/* ---------- public API ------------------------------------------------- */
+
+audio_worker_t *audio_worker_create(int audio_sample_rate,
+                                    int decim_ratio,
+                                    ftx_protocol_t proto,
+                                    int32_t filter_low_hz,
+                                    int32_t filter_high_hz,
+                                    const audio_worker_cb_t *cb) {
+    if ((decim_ratio <= 0) || (audio_sample_rate <= 0)) return NULL;
+    int span = filter_high_hz - filter_low_hz;
+    if (span <= 0) return NULL;
+
+    audio_worker_t *w = (audio_worker_t *)calloc(1, sizeof(*w));
+    if (!w) return NULL;
+
+    w->sample_rate    = audio_sample_rate;
+    w->decim          = decim_ratio;
+    w->worker_rate    = audio_sample_rate / decim_ratio;
+    w->proto          = proto;
+    w->filter_low_hz  = filter_low_hz;
+    w->filter_high_hz = filter_high_hz;
+    w->nfft           = (uint16_t)(WORKER_DISPLAY_WIDTH * w->worker_rate / span);
+    w->fps_ms         = (uint8_t)(1000 / 5);   /* 5 Hz update cap */
+    if (cb) w->cb = *cb;
+
+    pthread_mutex_init(&w->audio_mux, NULL);
+    pthread_mutex_init(&w->sleep_mux, NULL);
+    pthread_cond_init(&w->sleep_cv, NULL);
+
+    w->audio_buf = cbuffercf_create((unsigned int)(audio_sample_rate * 3));
+    if (!w->audio_buf) goto fail;
+
+    w->decim_dsp = firdecim_crcf_create_kaiser((unsigned int)decim_ratio, 8, 40.0f);
+    if (!w->decim_dsp) goto fail;
+    firdecim_crcf_set_scale(w->decim_dsp, 1.0f / (float)decim_ratio);
+
+    w->sg = spgramcf_create(w->nfft, LIQUID_WINDOW_HANN, w->nfft, w->nfft / 2);
+    if (!w->sg) goto fail;
+
+    w->psd = (float *)malloc(w->nfft * sizeof(float));
+    if (!w->psd) goto fail;
+
+    ftx_worker_init(w->worker_rate, proto);
+    w->block_size          = ftx_worker_get_block_size();
+    if (w->block_size <= 0) goto fail;
+
+    w->audio_frame_buf_len = (size_t)w->block_size * (size_t)decim_ratio;
+    w->audio_frame_buf     = (float complex *)malloc(w->audio_frame_buf_len * sizeof(float complex));
+    w->decim_buf           = (float complex *)malloc((size_t)w->block_size * sizeof(float complex));
+    if (!w->audio_frame_buf || !w->decim_buf) goto fail;
+
+    atomic_store(&w->stop_req, false);
+    atomic_store(&w->thread_running, false);
+
+    return w;
+
+fail:
+    audio_worker_destroy(w);
+    return NULL;
+}
+
+int audio_worker_start(audio_worker_t *w) {
+    if (!w) return -1;
+    atomic_store(&w->stop_req, false);
+    if (pthread_create(&w->thread, NULL, worker_main, w) != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+void audio_worker_stop(audio_worker_t *w) {
+    if (!w) return;
+    atomic_store(&w->stop_req, true);
+    pthread_mutex_lock(&w->sleep_mux);
+    pthread_cond_broadcast(&w->sleep_cv);
+    pthread_mutex_unlock(&w->sleep_mux);
+
+    if (atomic_load(&w->thread_running)) {
+        pthread_join(w->thread, NULL);
+    }
+    atomic_store(&w->thread_running, false);
+}
+
+void audio_worker_destroy(audio_worker_t *w) {
+    if (!w) return;
+    audio_worker_stop(w);
+
+    if (w->audio_frame_buf) { free(w->audio_frame_buf); w->audio_frame_buf = NULL; }
+    if (w->decim_buf)       { free(w->decim_buf);       w->decim_buf = NULL; }
+    if (w->psd)             { free(w->psd);             w->psd = NULL; }
+
+    if (w->sg)        { spgramcf_destroy(w->sg);              w->sg = NULL; }
+    if (w->decim_dsp) { firdecim_crcf_destroy(w->decim_dsp);  w->decim_dsp = NULL; }
+    if (w->audio_buf) { cbuffercf_destroy(w->audio_buf);      w->audio_buf = NULL; }
+
+    ftx_worker_free();
+
+    pthread_mutex_destroy(&w->audio_mux);
+    pthread_mutex_destroy(&w->sleep_mux);
+    pthread_cond_destroy(&w->sleep_cv);
+
+    free(w);
+}
+
+void audio_worker_feed(audio_worker_t *w, unsigned int n, float complex *samples) {
+    if (!w || !samples || (n == 0)) return;
+    pthread_mutex_lock(&w->audio_mux);
+    if (w->audio_buf) {
+        cbuffercf_write(w->audio_buf, samples, n);
+    }
+    pthread_mutex_unlock(&w->audio_mux);
+}
+
+uint16_t audio_worker_nfft(const audio_worker_t *w) {
+    return w ? w->nfft : 0;
+}

--- a/src/ft8/audio_worker.c
+++ b/src/ft8/audio_worker.c
@@ -18,6 +18,7 @@
 #include <time.h>
 
 #include <liquid/liquid.h>
+#include "util.h"
 #include <ft8lib/constants.h>
 
 #include "worker.h"
@@ -64,12 +65,6 @@ struct audio_worker_s {
 
 /* ---------- small helpers ---------------------------------------------- */
 
-static uint64_t now_ms(void) {
-    struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC, &ts);
-    return (uint64_t)ts.tv_sec * 1000ULL + (uint64_t)(ts.tv_nsec / 1000000L);
-}
-
 static bool get_time_slot(ftx_protocol_t proto, struct timespec now, float *sec_since_start) {
     float sec = (now.tv_sec % 60) + now.tv_nsec / 1.0e9f;
     float slot_time = (proto == FTX_PROTOCOL_FT4) ? FT4_SLOT_TIME : FT8_SLOT_TIME;
@@ -106,7 +101,7 @@ static void drain_audio_buf(audio_worker_t *w) {
 
 static void maybe_emit_psd(audio_worker_t *w, const slot_info_t *info,
                            float sec_since_slot_start) {
-    uint64_t now = now_ms();
+    uint64_t now = get_time();
     if ((now - w->last_psd_time_ms) < w->fps_ms) return;
     w->last_psd_time_ms = now;
 

--- a/src/ft8/audio_worker.h
+++ b/src/ft8/audio_worker.h
@@ -1,0 +1,91 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 audio / decode worker
+ *
+ *  Copyright (c) 2026
+ */
+
+/*
+ *  Owns the FT8 decoder thread and the realtime audio ring buffer that
+ *  feeds it. Uses cooperative shutdown via an atomic stop flag plus a
+ *  condition variable - never pthread_cancel. When audio_worker_stop()
+ *  returns, all DSP state (ftx_worker, firdecim, spgramcf) is in a
+ *  consistent state, so ftx_worker_free() is safe.
+ *
+ *  Business logic hooks are pure callbacks with value-semantic payloads:
+ *
+ *      on_message   - one FT8/FT4 decode (may fire 0..N times per iteration)
+ *      on_psd       - one waterfall PSD frame
+ *      on_slot_end  - slot boundary crossed, RX window closed, decoder reset
+ *      on_tick      - end-of-iteration hook, caller may perform blocking TX
+ *
+ *  All callbacks run on the worker thread. Handlers that need to touch LVGL
+ *  must scheduler_put() into the UI thread instead of poking LVGL directly.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <complex.h>
+
+#include <ft8lib/constants.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Per-RX-slot metadata exposed to callbacks. Kept minimal on purpose. */
+typedef struct {
+    bool odd;
+    bool answer_generated;
+} slot_info_t;
+
+typedef struct audio_worker_s audio_worker_t;
+
+typedef struct {
+    void (*on_message)(const char *text, int snr, float freq_hz,
+                       float time_sec,
+                       const slot_info_t *info, void *ctx);
+    void (*on_psd)(const float *psd, uint16_t nfft,
+                   float sec_since_slot_start,
+                   const slot_info_t *info, void *ctx);
+    void (*on_slot_end)(const slot_info_t *info, void *ctx);
+    /* End-of-iteration hook. Fires after rx processing and slot-end handling.
+     * The caller may perform a blocking TX here; on return, the worker loops
+     * back around and the stale audio accumulated during TX will be drained
+     * at the next slot boundary. */
+    void (*on_tick)(const slot_info_t *info,
+                    bool new_slot,
+                    float sec_since_slot_start,
+                    void *ctx);
+    void *ctx;
+} audio_worker_cb_t;
+
+/* Create + configure the worker. Does NOT start the thread. */
+audio_worker_t *audio_worker_create(int audio_sample_rate,
+                                    int decim_ratio,
+                                    ftx_protocol_t proto,
+                                    int32_t filter_low_hz,
+                                    int32_t filter_high_hz,
+                                    const audio_worker_cb_t *cb);
+
+/* Start the decode thread. */
+int audio_worker_start(audio_worker_t *w);
+
+/* Cooperative shutdown: set stop flag, signal cv, join. No pthread_cancel. */
+void audio_worker_stop(audio_worker_t *w);
+
+/* Release all resources. Calls audio_worker_stop() first if still running. */
+void audio_worker_destroy(audio_worker_t *w);
+
+/* Push audio samples from the radio audio callback (any thread). */
+void audio_worker_feed(audio_worker_t *w, unsigned int n, float complex *samples);
+
+/* Waterfall FFT size chosen from filter bandwidth at create time. */
+uint16_t audio_worker_nfft(const audio_worker_t *w);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ft8/cq_scheduler.c
+++ b/src/ft8/cq_scheduler.c
@@ -1,0 +1,40 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 CQ scheduler
+ *
+ *  Copyright (c) 2026
+ */
+
+#include "cq_scheduler.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include <ft8lib/message.h>
+
+#include "lvgl/lvgl.h"
+
+void cq_make_message(const char *callsign,
+                     const char *qth,
+                     const char *cq_mod,
+                     char       *out) {
+    char buf[128];
+    if (strlen(cq_mod)) {
+        snprintf(buf, FTX_MAX_MESSAGE_LENGTH, "CQ_%s %s %.4s", cq_mod, callsign, qth);
+    } else {
+        snprintf(buf, FTX_MAX_MESSAGE_LENGTH, "CQ %s %.4s", callsign, qth);
+    }
+
+    ftx_message_rc_t rc;
+    ftx_message_t    msg;
+    rc = ftx_message_encode(&msg, NULL, buf);
+    if (rc != FTX_MESSAGE_RC_OK) {
+        LV_LOG_USER("Error: %d while encoding message: '%s'", rc, buf);
+    }
+    rc = ftx_message_decode(&msg, NULL, buf);
+    if (rc != FTX_MESSAGE_RC_OK) {
+        LV_LOG_USER("Error: %d while decoding message: '%s'", rc, buf);
+    }
+    strcpy(out, buf);
+}

--- a/src/ft8/cq_scheduler.h
+++ b/src/ft8/cq_scheduler.h
@@ -1,0 +1,36 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 CQ scheduler
+ *
+ *  Copyright (c) 2026
+ */
+
+/*
+ *  Composes outgoing CQ TX messages. Currently exposes just the message
+ *  builder; higher-level scheduling (when to actually queue a CQ for the
+ *  next slot, pausing for an active QSO, etc.) lives in dialog_ft8.c for
+ *  now. This header is a placeholder boundary for future moves.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Build a canonical FT8 CQ message of the form
+ *   "CQ <callsign> <grid>"               (no modifier)
+ *   "CQ_<mod> <callsign> <grid>"         (with modifier)
+ * The result is written to 'out' (caller-allocated). Behaviour matches
+ * the historical make_cq_msg() in dialog_ft8.c: the message is round-
+ * tripped through ftx_message_{encode,decode} for validation, and any
+ * codec error is logged via LV_LOG_USER but does NOT clear 'out'. */
+void cq_make_message(const char *callsign,
+                     const char *qth,
+                     const char *cq_mod,
+                     char       *out);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ft8/gfsk.c
+++ b/src/ft8/gfsk.c
@@ -32,6 +32,9 @@ int16_t *gfsk_synth(const uint8_t *symbols, uint16_t n_sym, float f0, float symb
     float    dphi_peak = 2 * M_PI * hmod / n_spsym;
     float    dphi[n_wave + 2 * n_spsym];
     int16_t *samples = malloc(sizeof(int16_t) * n_wave);
+    if (!samples) {
+        return NULL;
+    }
 
     *n_samples = n_wave;
 

--- a/src/ft8/qso.cpp
+++ b/src/ft8/qso.cpp
@@ -76,9 +76,10 @@ std::string Candidate::get_tx_text(std::string local_callsign, std::string local
 }
 
 void Candidate::save_qso(save_qso_cb_t save_qso_cb) {
-    if (can_be_saved())
+    if (save_qso_cb && can_be_saved()) {
         save_qso_cb(_remote_callsign.c_str(), _grid.c_str(), _rcvd_snr, _sent_snr);
         _saved = true;
+    }
 }
 
 FTxQsoProcessor::FTxQsoProcessor(std::string local_callsign, std::string local_qth, save_qso_cb_t save_qso_cb, int max_repeats) {
@@ -107,6 +108,10 @@ void FTxQsoProcessor::add_rx_text(std::string text, const int snr, ftx_msg_meta_
 
     std::vector<std::string> tokens = split_text(text);
 
+    if (tokens.empty()) {
+        return;
+    }
+
     if ((tokens.size() >= 5) && (text.find(';') != text.npos)) {
         // "A2AA RR73; R2RFE <RP79AA> +05"
         std::vector<std::string> new_tokens;
@@ -122,12 +127,15 @@ void FTxQsoProcessor::add_rx_text(std::string text, const int snr, ftx_msg_meta_
         tokens = new_tokens;
     }
 
-    for (auto it = tokens.begin(); it != tokens.end(); it++) {
-        if (it->at(0) == '<') {
-            *it = it->substr(1, it->length() - 2);
-        }
+    if (tokens.empty()) {
+        return;
     }
 
+    for (auto &token : tokens) {
+        if (!token.empty() && token[0] == '<') {
+            token = token.substr(1, token.length() - 2);
+        }
+    }
 
     if (tokens[0] == "CQ") {
         process_cq(meta, tokens, snr);
@@ -429,4 +437,13 @@ bool ftx_qso_processor_can_save_qso(FTxQsoProcessor *p) {
 
 bool ftx_qso_processor_force_save_qso(FTxQsoProcessor *p) {
     return p->force_save_qso();
+}
+
+bool FTxQsoProcessor::has_current() {
+    return _cur_candidate != NULL;
+}
+
+bool ftx_qso_processor_has_current(FTxQsoProcessor *p) {
+    if (!p) return false;
+    return p->has_current();
 }

--- a/src/ft8/qso.cpp
+++ b/src/ft8/qso.cpp
@@ -127,10 +127,6 @@ void FTxQsoProcessor::add_rx_text(std::string text, const int snr, ftx_msg_meta_
         tokens = new_tokens;
     }
 
-    if (tokens.empty()) {
-        return;
-    }
-
     for (auto &token : tokens) {
         if (!token.empty() && token[0] == '<') {
             token = token.substr(1, token.length() - 2);
@@ -377,6 +373,10 @@ Candidate *FTxQsoProcessor::get_or_create_cur_candidate(std::string remote_calls
     return _cur_candidate;
 }
 
+bool FTxQsoProcessor::has_current() {
+    return _cur_candidate != NULL;
+}
+
 static std::string make_answer_text(ftx_msg_type_t last_rx_type, std::string remote_callsign,
                                     std::string local_callsign, const int local_snr, std::string grid) {
     char answer[35];
@@ -437,10 +437,6 @@ bool ftx_qso_processor_can_save_qso(FTxQsoProcessor *p) {
 
 bool ftx_qso_processor_force_save_qso(FTxQsoProcessor *p) {
     return p->force_save_qso();
-}
-
-bool FTxQsoProcessor::has_current() {
-    return _cur_candidate != NULL;
 }
 
 bool ftx_qso_processor_has_current(FTxQsoProcessor *p) {

--- a/src/ft8/qso.h
+++ b/src/ft8/qso.h
@@ -92,6 +92,7 @@ class FTxQsoProcessor {
 
     bool can_save_qso();
     bool force_save_qso();
+    bool has_current();
 
   private:
     bool          _auto    = true;
@@ -127,6 +128,7 @@ extern void ftx_qso_processor_start_qso(FTxQsoProcessor *p, ftx_msg_meta_t *meta
 
 extern bool ftx_qso_processor_can_save_qso(FTxQsoProcessor *p);
 extern bool ftx_qso_processor_force_save_qso(FTxQsoProcessor *p);
+extern bool ftx_qso_processor_has_current(FTxQsoProcessor *p);
 
 #ifdef __cplusplus
 }

--- a/src/ft8/table_view.c
+++ b/src/ft8/table_view.c
@@ -1,0 +1,358 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 message table view
+ *
+ *  Copyright (c) 2026
+ */
+
+#include "table_view.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "../events.h"
+
+/*
+ *  Cell data is owned by a fixed-size ring pool. We do NOT use LVGL's
+ *  cell user_data API: lv_table_set_cell_user_data() internally calls
+ *  lv_mem_free() on the previous user_data pointer (treating it as a
+ *  malloc'd buffer), which would crash on our pool indices. Instead we
+ *  keep a parallel s_row_cell[] mapping table row -> cell_data_t* in
+ *  this module, and never touch LVGL's user_data slot at all.
+ *
+ *  Size invariant:
+ *      CELL_POOL_SIZE  >= MAX_TABLE_MSG + CLEAN_N_ROWS
+ *  Worst case, the table holds MAX_TABLE_MSG rows; one pending push
+ *  touches the next slot before truncate_oldest() runs. Any slot that
+ *  the ring write cursor is about to overwrite is guaranteed to have
+ *  been truncated out of the table by that point.
+ */
+
+#define MAX_TABLE_MSG               512
+#define CLEAN_N_ROWS                 64
+#define CELL_POOL_SIZE              576  /* MAX_TABLE_MSG + CLEAN_N_ROWS */
+#define TABLE_MAX_ROWS_INTERNAL     576  /* upper bound on row index used */
+#define WAIT_SYNC_TEXT              "Wait sync"
+
+static cell_data_t            s_pool[CELL_POOL_SIZE];
+static uint16_t               s_pool_write = 0;
+static cell_data_t           *s_row_cell[TABLE_MAX_ROWS_INTERNAL]; /* row -> pool entry, NULL if none */
+
+static lv_obj_t              *s_table      = NULL;
+static table_view_press_cb_t  s_press_cb   = NULL;
+static table_view_actions_t   s_actions    = {0};
+
+static inline cell_data_t *row_cell(uint16_t r) {
+    if (r >= TABLE_MAX_ROWS_INTERNAL) return NULL;
+    return s_row_cell[r];
+}
+
+static inline void set_row_cell(uint16_t r, cell_data_t *cd) {
+    if (r >= TABLE_MAX_ROWS_INTERNAL) return;
+    s_row_cell[r] = cd;
+}
+
+static cell_data_t *pool_alloc_and_copy(const cell_data_t *src) {
+    cell_data_t *c = &s_pool[s_pool_write];
+    s_pool_write = (uint16_t)((s_pool_write + 1u) % CELL_POOL_SIZE);
+    *c = *src;
+    c->text[sizeof(c->text) - 1] = '\0';
+    return c;
+}
+
+static void truncate_oldest(void) {
+    if (!s_table) return;
+
+    uint16_t rows = lv_table_get_row_cnt(s_table);
+    if (rows <= MAX_TABLE_MSG) return;
+
+    lv_table_t *tbl = (lv_table_t *)s_table;
+    lv_coord_t  removed_height = 0;
+    for (size_t i = 0; i < CLEAN_N_ROWS; i++) {
+        removed_height += tbl->row_h[i];
+    }
+    if (tbl->row_act > CLEAN_N_ROWS) {
+        tbl->row_act -= CLEAN_N_ROWS;
+    } else {
+        tbl->row_act = 0;
+    }
+
+    /* Shift rows up: LVGL copies cell text, our parallel s_row_cell[]
+     * gets memmove'd in lockstep. No allocations, no frees, and we never
+     * touch LVGL's user_data slot. */
+    for (uint16_t i = CLEAN_N_ROWS; i < rows; i++) {
+        const char *val = lv_table_get_cell_value(s_table, i, 0);
+        lv_table_set_cell_value(s_table, (uint16_t)(i - CLEAN_N_ROWS), 0, val ? val : "");
+    }
+    if (rows > CLEAN_N_ROWS) {
+        memmove(&s_row_cell[0], &s_row_cell[CLEAN_N_ROWS],
+                (size_t)(rows - CLEAN_N_ROWS) * sizeof(s_row_cell[0]));
+    }
+    /* Zero out the tail entries that were just shifted away. */
+    for (uint16_t i = (uint16_t)(rows - CLEAN_N_ROWS); i < rows; i++) {
+        set_row_cell(i, NULL);
+    }
+
+    rows = (uint16_t)(rows - CLEAN_N_ROWS);
+    lv_table_set_row_cnt(s_table, rows);
+    lv_obj_scroll_by_bounded(s_table, 0, removed_height, LV_ANIM_OFF);
+}
+
+/* Return true if this cell_data_t matches an RX-header row ("RX ..."). */
+static bool is_rx_header(const cell_data_t *cd) {
+    return cd && (cd->cell_type == CELL_RX_INFO) &&
+           (strncmp(cd->text, "RX ", 3) == 0);
+}
+
+void table_view_push_ui(const cell_data_t *src) {
+    if (!s_table || !src) return;
+
+    truncate_oldest();
+
+    uint16_t rows = lv_table_get_row_cnt(s_table);
+    if ((rows == 1) && (strcmp(lv_table_get_cell_value(s_table, 0, 0), WAIT_SYNC_TEXT) == 0)) {
+        /* The single "Wait sync" placeholder is about to be replaced. */
+        rows = 0;
+    }
+
+    /* Row autoscroll: keep scrolled-to-bottom unless the user moved away. */
+    uint16_t selected_row = 0;
+    uint16_t selected_col = 0;
+    lv_table_get_selected_cell(s_table, &selected_row, &selected_col);
+    bool scroll = (rows == (uint16_t)(selected_row + 1));
+
+    /* In-place RX-header collapse: replace the last row text instead of
+     * appending another identical "RX ..." marker. */
+    if (is_rx_header(src) && (rows > 0)) {
+        uint16_t last = (uint16_t)(rows - 1);
+        cell_data_t *last_cd = row_cell(last);
+        if (last_cd && is_rx_header(last_cd)) {
+            strncpy(last_cd->text, src->text, sizeof(last_cd->text) - 1);
+            last_cd->text[sizeof(last_cd->text) - 1] = '\0';
+            lv_table_set_cell_value(s_table, last, 0, last_cd->text);
+            return;
+        }
+    }
+
+    cell_data_t *stored = pool_alloc_and_copy(src);
+    lv_table_set_cell_value(s_table, rows, 0, stored->text);
+    set_row_cell(rows, stored);
+
+    if (scroll) {
+        static int32_t c = LV_KEY_DOWN;
+        lv_event_send(s_table, LV_EVENT_KEY, &c);
+    }
+}
+
+void table_view_add_msg_cb(void *data) {
+    table_view_push_ui((const cell_data_t *)data);
+}
+
+void table_view_reset(void) {
+    if (!s_table) return;
+
+    /* Clear our parallel row->cell map; LVGL's user_data slot is never
+     * touched (it stays NULL), so there is no stale-pointer free path
+     * during set_row_cnt() shrink. */
+    memset(s_row_cell, 0, sizeof(s_row_cell));
+    lv_table_set_row_cnt(s_table, 1);
+    lv_table_set_cell_value(s_table, 0, 0, WAIT_SYNC_TEXT);
+    s_pool_write = 0;
+}
+
+/* -------- LVGL event plumbing ------------------------------------------ */
+
+static void draw_part_begin_cb(lv_event_t *e) {
+    lv_obj_t               *obj = lv_event_get_target(e);
+    lv_obj_draw_part_dsc_t *dsc = lv_event_get_draw_part_dsc(e);
+
+    if (dsc->part != LV_PART_ITEMS) return;
+
+    uint32_t row = dsc->id / lv_table_get_col_cnt(obj);
+    uint32_t col = dsc->id - row * lv_table_get_col_cnt(obj);
+    (void)col;
+    cell_data_t *cd = row_cell((uint16_t)row);
+
+    dsc->rect_dsc->bg_opa = LV_OPA_50;
+
+    if (!cd) {
+        dsc->label_dsc->align = LV_TEXT_ALIGN_CENTER;
+        dsc->rect_dsc->bg_color = lv_color_hex(0x303030);
+    } else {
+        switch (cd->cell_type) {
+        case CELL_RX_INFO:
+            dsc->label_dsc->align = LV_TEXT_ALIGN_CENTER;
+            dsc->rect_dsc->bg_color = lv_color_hex(0x303030);
+            break;
+        case CELL_RX_CQ:
+            switch (cd->worked_type) {
+            case SEARCH_WORKED_NO:
+                dsc->rect_dsc->bg_color = lv_color_hex(0x00DD00);
+                break;
+            case SEARCH_WORKED_YES:
+                dsc->label_dsc->opa = LV_OPA_90;
+                dsc->rect_dsc->bg_color = lv_color_hex(0x2e5a00);
+                break;
+            case SEARCH_WORKED_SAME_MODE:
+                dsc->label_dsc->decor = LV_TEXT_DECOR_STRIKETHROUGH;
+                dsc->label_dsc->opa   = LV_OPA_80;
+                dsc->rect_dsc->bg_color = lv_color_hex(0x224400);
+                break;
+            }
+            break;
+        case CELL_RX_TO_ME:
+            dsc->rect_dsc->bg_color = lv_color_hex(0xFF0000);
+            break;
+        case CELL_TX_MSG:
+            dsc->rect_dsc->bg_color = lv_color_hex(0x0000FF);
+            break;
+        default:
+            dsc->rect_dsc->bg_color = lv_color_black();
+            break;
+        }
+    }
+
+    uint16_t selected_row;
+    uint16_t selected_col;
+    lv_table_get_selected_cell(obj, &selected_row, &selected_col);
+    if (selected_row == row) {
+        dsc->rect_dsc->bg_color = lv_color_lighten(dsc->rect_dsc->bg_color, 20);
+    }
+}
+
+static void draw_part_end_cb(lv_event_t *e) {
+    lv_obj_t               *obj = lv_event_get_target(e);
+    lv_obj_draw_part_dsc_t *dsc = lv_event_get_draw_part_dsc(e);
+
+    if (dsc->part != LV_PART_ITEMS) return;
+
+    uint32_t row = dsc->id / lv_table_get_col_cnt(obj);
+    uint32_t col = dsc->id - row * lv_table_get_col_cnt(obj);
+    (void)col;
+    cell_data_t *cd = row_cell((uint16_t)row);
+    if (!cd) return;
+
+    if ((cd->cell_type != CELL_RX_MSG) &&
+        (cd->cell_type != CELL_RX_CQ) &&
+        (cd->cell_type != CELL_RX_TO_ME)) {
+        return;
+    }
+
+    char              buf[64];
+    const lv_coord_t  cell_top    = lv_obj_get_style_pad_top(obj, LV_PART_ITEMS);
+    const lv_coord_t  cell_bottom = lv_obj_get_style_pad_bottom(obj, LV_PART_ITEMS);
+    lv_area_t         area;
+
+    dsc->label_dsc->align = LV_TEXT_ALIGN_RIGHT;
+
+    area.y1 = dsc->draw_area->y1 + cell_top;
+    area.y2 = dsc->draw_area->y2 - cell_bottom;
+    area.x2 = dsc->draw_area->x2 - 15;
+    area.x1 = area.x2 - 120;
+
+    snprintf(buf, sizeof(buf), "%i dB", cd->meta.local_snr);
+    lv_draw_label(dsc->draw_ctx, dsc->label_dsc, &area, buf, NULL);
+
+    if (cd->dist > 0) {
+        area.x2 = area.x1 - 10;
+        area.x1 = area.x2 - 200;
+        snprintf(buf, sizeof(buf), "%i km", cd->dist);
+        lv_draw_label(dsc->draw_ctx, dsc->label_dsc, &area, buf, NULL);
+    }
+}
+
+static void cell_press_cb(lv_event_t *e) {
+    (void)e;
+    if (!s_press_cb) return;
+
+    uint16_t row, col;
+    lv_table_get_selected_cell(s_table, &row, &col);
+    (void)col;
+    cell_data_t *cd = row_cell(row);
+    s_press_cb(cd);
+}
+
+static void key_cb(lv_event_t *e) {
+    uint32_t key = *((uint32_t *)lv_event_get_param(e));
+
+    switch (key) {
+    case LV_KEY_ESC:
+        if (s_actions.on_close) s_actions.on_close();
+        break;
+    case KEY_VOL_LEFT_EDIT:
+    case KEY_VOL_LEFT_SELECT:
+        if (s_actions.on_vol_change) s_actions.on_vol_change(-1);
+        break;
+    case KEY_VOL_RIGHT_EDIT:
+    case KEY_VOL_RIGHT_SELECT:
+        if (s_actions.on_vol_change) s_actions.on_vol_change(1);
+        break;
+    default:
+        break;
+    }
+}
+
+void table_view_build(lv_obj_t *parent, lv_coord_t x, lv_coord_t y, lv_coord_t w, lv_coord_t h) {
+    s_pool_write = 0;
+    s_press_cb   = NULL;
+    memset(&s_actions, 0, sizeof(s_actions));
+    memset(s_row_cell, 0, sizeof(s_row_cell));
+
+    s_table = lv_table_create(parent);
+    lv_obj_remove_style(s_table, NULL, LV_STATE_ANY | LV_PART_MAIN);
+    lv_obj_add_event_cb(s_table, cell_press_cb, LV_EVENT_PRESSED, NULL);
+    lv_obj_add_event_cb(s_table, key_cb, LV_EVENT_KEY, NULL);
+    lv_obj_add_event_cb(s_table, draw_part_begin_cb, LV_EVENT_DRAW_PART_BEGIN, NULL);
+    lv_obj_add_event_cb(s_table, draw_part_end_cb,   LV_EVENT_DRAW_PART_END,   NULL);
+
+    lv_obj_set_size(s_table, w, h);
+    lv_obj_set_pos(s_table, x, y);
+
+    lv_table_set_col_cnt(s_table, 1);
+    lv_table_set_col_width(s_table, 0, w - 2);
+
+    lv_obj_set_style_border_width(s_table, 0, LV_PART_ITEMS);
+    lv_obj_set_style_bg_opa(s_table, 192, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(s_table, lv_color_black(), LV_PART_MAIN);
+    lv_obj_set_style_border_width(s_table, 1, LV_PART_MAIN);
+    lv_obj_set_style_border_color(s_table, lv_color_white(), LV_PART_MAIN);
+    lv_obj_set_style_border_opa(s_table, 128, LV_PART_MAIN);
+    lv_obj_set_style_text_color(s_table, lv_color_hex(0xC0C0C0), LV_PART_ITEMS);
+    lv_obj_set_style_pad_top(s_table, 3, LV_PART_ITEMS);
+    lv_obj_set_style_pad_bottom(s_table, 3, LV_PART_ITEMS);
+    lv_obj_set_style_pad_left(s_table, 5, LV_PART_ITEMS);
+    lv_obj_set_style_pad_right(s_table, 0, LV_PART_ITEMS);
+
+    lv_table_set_cell_value(s_table, 0, 0, WAIT_SYNC_TEXT);
+}
+
+void table_view_destroy(void) {
+    if (s_table) {
+        /* LVGL will delete its internal cell strings; we never wrote to
+         * cell user_data, so its NULL slots have nothing to free. */
+        lv_obj_del(s_table);
+        s_table = NULL;
+    }
+    s_press_cb = NULL;
+    memset(&s_actions, 0, sizeof(s_actions));
+    memset(s_row_cell, 0, sizeof(s_row_cell));
+    s_pool_write = 0;
+}
+
+lv_obj_t *table_view_obj(void) {
+    return s_table;
+}
+
+void table_view_set_press_cb(table_view_press_cb_t cb) {
+    s_press_cb = cb;
+}
+
+void table_view_set_actions(const table_view_actions_t *actions) {
+    if (actions) {
+        s_actions = *actions;
+    } else {
+        memset(&s_actions, 0, sizeof(s_actions));
+    }
+}

--- a/src/ft8/table_view.c
+++ b/src/ft8/table_view.c
@@ -100,10 +100,9 @@ static void truncate_oldest(void) {
     lv_obj_scroll_by_bounded(s_table, 0, removed_height, LV_ANIM_OFF);
 }
 
-/* Return true if this cell_data_t matches an RX-header row ("RX ..."). */
+/* Return true if this cell_data_t matches an RX-header row. */
 static bool is_rx_header(const cell_data_t *cd) {
-    return cd && (cd->cell_type == CELL_RX_INFO) &&
-           (strncmp(cd->text, "RX ", 3) == 0);
+    return cd && (cd->cell_type == CELL_RX_INFO);
 }
 
 void table_view_push_ui(const cell_data_t *src) {
@@ -182,6 +181,7 @@ static void draw_part_begin_cb(lv_event_t *e) {
         dsc->rect_dsc->bg_color = lv_color_hex(0x303030);
     } else {
         switch (cd->cell_type) {
+        case CELL_START_QSO:
         case CELL_RX_INFO:
             dsc->label_dsc->align = LV_TEXT_ALIGN_CENTER;
             dsc->rect_dsc->bg_color = lv_color_hex(0x303030);

--- a/src/ft8/table_view.h
+++ b/src/ft8/table_view.h
@@ -1,0 +1,88 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 message table view
+ *
+ *  Copyright (c) 2026
+ */
+
+/*
+ *  Wraps the LVGL lv_table that displays FT8 RX/TX messages. Owns the cell
+ *  backing data in a fixed-size ring pool, so truncate/scroll/close never
+ *  call malloc or free and there is no way to leak or double-free a cell.
+ *
+ *  Usage (UI thread only unless noted):
+ *      table_view_build(parent, x, y, w, h);
+ *      table_view_set_press_cb(on_press);
+ *      table_view_set_actions(&actions);
+ *
+ *      // from worker thread:
+ *      cell_data_t cd = ...;
+ *      scheduler_put(table_view_add_msg_cb, &cd, sizeof(cd));
+ *
+ *      // on dialog close:
+ *      table_view_destroy();
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "lvgl/lvgl.h"
+
+#include "../qso_log.h"
+#include "qso.h"   /* ftx_msg_meta_t */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    CELL_RX_INFO = 0,
+    CELL_RX_MSG,
+    CELL_RX_CQ,
+    CELL_RX_TO_ME,
+    CELL_TX_MSG,
+} ft8_cell_type_t;
+
+typedef struct {
+    ft8_cell_type_t         cell_type;
+    int16_t                 dist;
+    bool                    odd;
+    ftx_msg_meta_t          meta;
+    char                    text[64];
+    qso_log_search_worked_t worked_type;
+} cell_data_t;
+
+/* Optional dialog-level actions invoked from the table's key handler. */
+typedef struct {
+    void (*on_close)(void);           /* LV_KEY_ESC */
+    void (*on_vol_change)(int32_t d); /* KEY_VOL_*_EDIT/SELECT */
+} table_view_actions_t;
+
+/* Fired when a data-bearing row (RX_MSG / RX_CQ / RX_TO_ME) is pressed. */
+typedef void (*table_view_press_cb_t)(const cell_data_t *cell);
+
+void      table_view_build(lv_obj_t *parent, lv_coord_t x, lv_coord_t y, lv_coord_t w, lv_coord_t h);
+void      table_view_destroy(void);
+lv_obj_t *table_view_obj(void);
+
+void table_view_set_press_cb(table_view_press_cb_t cb);
+void table_view_set_actions(const table_view_actions_t *actions);
+
+/* Clear table + ring pool and show a single "Wait sync" placeholder row. */
+void table_view_reset(void);
+
+/* Insert on the UI thread. Prefer the scheduler trampoline below from
+ * worker threads. The text field is used as the visible row content. */
+void table_view_push_ui(const cell_data_t *src);
+
+/* Trampoline that matches scheduler_fn_t signature. Expects 'data' to point
+ * to a cell_data_t value copy that the scheduler will free after this
+ * returns; table_view_push_ui() takes its own snapshot into the ring pool. */
+void table_view_add_msg_cb(void *data);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ft8/table_view.h
+++ b/src/ft8/table_view.h
@@ -40,6 +40,7 @@ extern "C" {
 
 typedef enum {
     CELL_RX_INFO = 0,
+    CELL_START_QSO,
     CELL_RX_MSG,
     CELL_RX_CQ,
     CELL_RX_TO_ME,

--- a/src/ft8/tx_worker.c
+++ b/src/ft8/tx_worker.c
@@ -1,0 +1,122 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 TX player
+ *
+ *  Copyright (c) 2026
+ */
+
+#include "tx_worker.h"
+
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "lvgl/lvgl.h"
+
+#include "../audio.h"
+#include "../cfg/cfg.h"
+#include "../cfg/subjects.h"
+#include "../params/params.h"
+#include "../radio.h"
+#include "../tx_info.h"
+#include "worker.h"
+
+/* FT8 audio tone offset inside the radio passband. */
+#define SIGNAL_FREQ_HZ   1325
+#define MAX_PWR_W        5.0f
+#define GAIN_MIN_DB     (-30.0f)
+#define GAIN_MAX_DB      0.0f
+
+/* ALC-driven gain correction (legacy formula from dialog_ft8.c). */
+static float get_correction(void) {
+    static uint8_t msg_id = 0;
+    float correction = 0.0f;
+    float pwr        = 0.0f;
+    float alc        = 0.0f;
+
+    if (tx_info_refresh(&msg_id, &alc, &pwr, NULL)) {
+        float target_pwr = LV_MIN(subject_get_float(cfg.pwr.val), MAX_PWR_W);
+        if (alc > 0.5f) {
+            correction = log10f(log10f(11.1f - alc)) * 20.0f - 0.38f;
+        } else if (target_pwr - pwr > 0.5f) {
+            correction = log10f(target_pwr / (pwr + 0.01f)) * 10.0f;
+        }
+    }
+    return correction;
+}
+
+bool tx_worker_run(const char    *tx_text,
+                   int32_t        audio_sample_rate,
+                   float          base_gain_offset,
+                   tx_abort_fn_t  abort_check,
+                   void          *abort_check_ctx) {
+    int16_t *samples   = NULL;
+    uint32_t n_samples = 0;
+
+    if (!ftx_worker_generate_tx_samples(tx_text, SIGNAL_FREQ_HZ,
+                                        (uint32_t)audio_sample_rate,
+                                        &samples, &n_samples)) {
+        return true; /* nothing to send; not an abort */
+    }
+
+    if (subject_get_float(cfg.pwr.val) > MAX_PWR_W) {
+        radio_set_pwr(MAX_PWR_W);
+    }
+
+    float gain_offset      = base_gain_offset + params.ft8_output_gain_offset.x;
+    float play_gain_offset = audio_set_play_vol(gain_offset + 6.0f);
+    gain_offset           -= play_gain_offset;
+
+    uint64_t radio_freq = subject_get_int(cfg_cur.fg_freq);
+    radio_set_freq((int32_t)radio_freq + (int32_t)params.ft8_tx_freq.x - SIGNAL_FREQ_HZ);
+    radio_set_modem(true);
+
+    float    prev_gain_offset = gain_offset;
+    size_t   counter          = 0;
+    int16_t *ptr              = samples;
+    size_t   part;
+
+    bool aborted = false;
+    while (true) {
+        if (counter > 30) {
+            gain_offset += get_correction() * 0.4f;
+            if (gain_offset > GAIN_MAX_DB) {
+                gain_offset = GAIN_MAX_DB;
+            } else if (gain_offset < GAIN_MIN_DB) {
+                gain_offset = GAIN_MIN_DB;
+            }
+        }
+        if (n_samples <= 0) {
+            break;
+        }
+        if (abort_check && abort_check(abort_check_ctx)) {
+            aborted = true;
+            break;
+        }
+        part = LV_MIN(1024 * 2, n_samples);
+        if (gain_offset == prev_gain_offset) {
+            if (gain_offset != 0.0f) {
+                audio_gain_db(ptr, part, gain_offset, ptr);
+            }
+        } else {
+            audio_gain_db_transition(ptr, part, prev_gain_offset, gain_offset, ptr);
+            prev_gain_offset = gain_offset;
+        }
+        audio_play(ptr, part);
+        n_samples -= part;
+        ptr       += part;
+        counter++;
+    }
+
+    params_float_set(&params.ft8_output_gain_offset,
+                     gain_offset - base_gain_offset + play_gain_offset);
+    audio_play_wait();
+    radio_set_modem(false);
+    radio_set_freq((int32_t)radio_freq);
+    free(samples);
+    audio_set_play_vol(params.play_gain_db_f.x);
+
+    return !aborted;
+}

--- a/src/ft8/tx_worker.h
+++ b/src/ft8/tx_worker.h
@@ -1,0 +1,43 @@
+/*
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ *  Xiegu X6100 LVGL GUI - FT8 TX player
+ *
+ *  Copyright (c) 2026
+ */
+
+/*
+ *  Synthesises an FT8/FT4 TX waveform from tx_text and pushes it to the
+ *  audio output with per-block ALC-based gain correction. Blocks for the
+ *  duration of one slot, so it is invoked from the decode thread between
+ *  RX frames.
+ *
+ *  The caller supplies an abort-check callback that the worker polls each
+ *  block, so dialog state (e.g. dialog_ft8.c's ft8_state_t) can preempt
+ *  TX without this module owning that state itself.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Abort-check callback. Return true to stop TX after the current block. */
+typedef bool (*tx_abort_fn_t)(void *ctx);
+
+/* Transmit tx_text. Returns true on normal completion (or no-op when
+ * sample generation fails); returns false if the abort callback fired
+ * mid-transmit. */
+bool tx_worker_run(const char    *tx_text,
+                   int32_t        audio_sample_rate,
+                   float          base_gain_offset,
+                   tx_abort_fn_t  abort_check,
+                   void          *abort_check_ctx);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ft8/worker.c
+++ b/src/ft8/worker.c
@@ -21,13 +21,17 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
+#include <errno.h>
+#include <ctype.h>
 
 #define MAX_CANDIDATES 200
 #define MAX_DECODED_MESSAGES 50
 #define LDPC_ITERATIONS 25
 #define TIME_OSR 4               // Time oversampling rate (symbol subdivision)
 #define FREQ_OSR 2               // Frequency oversampling rate (bin subdivision)
-#define MIN_SCORE 10             // Minimum score for candidate
+#define FTXLIB_MIN_SCORE_DEFAULT 10
+#define FTXLIB_MIN_SCORE_PATH "/mnt/ft8lib_min_score.txt"
 #define DECODE_BLOCK_STRIDE 2    // Try to decode each N block
 #define EARLY_LDPC_ITERATIONS 25 // LDPC iterations on early decoding
 
@@ -44,6 +48,49 @@ static int   nfft;
 
 static uint8_t n_tones;  // Number of tones for generate message and check minimal length for rx
 static uint8_t sync_num; // Length of sync
+
+/* Decode score threshold (minimum candidate score). Initialised from
+ * FTXLIB_MIN_SCORE_PATH on first ftx_worker_init() so a power user can
+ * tweak sensitivity vs false-positive rate without a rebuild. The file is
+ * (re)created with the default value when missing or unparsable. */
+static int             ft8lib_min_score = FTXLIB_MIN_SCORE_DEFAULT;
+
+static void ftx_min_score_write_default(void) {
+    FILE *wf = fopen(FTXLIB_MIN_SCORE_PATH, "w");
+    if (!wf) return;
+    fprintf(wf, "%d\n", FTXLIB_MIN_SCORE_DEFAULT);
+    fclose(wf);
+}
+
+static void ftx_min_score_load_or_create(void) {
+    FILE *f = fopen(FTXLIB_MIN_SCORE_PATH, "r");
+    if (!f) {
+        if (errno == ENOENT) {
+            ftx_min_score_write_default();
+        }
+        ft8lib_min_score = FTXLIB_MIN_SCORE_DEFAULT;
+        return;
+    }
+    char buf[64] = {0};
+    bool ok = false;
+    if (fgets(buf, sizeof(buf), f)) {
+        char *end = NULL;
+        errno = 0;
+        long v = strtol(buf, &end, 10);
+        if ((errno == 0) && (end != buf) && (v >= 0) && (v <= 32767)) {
+            while (end && *end && isspace((unsigned char)*end)) end++;
+            if ((end != NULL) && (*end == '\0')) {
+                ft8lib_min_score = (int)v;
+                ok = true;
+            }
+        }
+    }
+    fclose(f);
+    if (!ok) {
+        ft8lib_min_score = FTXLIB_MIN_SCORE_DEFAULT;
+        ftx_min_score_write_default();
+    }
+}
 
 static int             num_candidates;
 static ftx_candidate_t candidate_list[MAX_CANDIDATES];
@@ -62,6 +109,7 @@ static int get_message_snr(const ftx_waterfall_t *wf, const ftx_candidate_t *can
  * Init worker
  */
 void ftx_worker_init(int sample_rate, ftx_protocol_t protocol) {
+    ftx_min_score_load_or_create();
     float slot_period;
 
     switch (protocol) {
@@ -79,6 +127,7 @@ void ftx_worker_init(int sample_rate, ftx_protocol_t protocol) {
         break;
     default:
         LV_LOG_ERROR("Unsupported protocol: %lu", protocol);
+        return;
     }
     int num_samples = slot_period * sample_rate;
 
@@ -93,7 +142,20 @@ void ftx_worker_init(int sample_rate, ftx_protocol_t protocol) {
     // TODO: skip bins outside filter
     const int num_bins = sample_rate * symbol_period / 2;
 
-    size_t mag_size = max_blocks * TIME_OSR * FREQ_OSR * num_bins * sizeof(WF_ELEM_T);
+    /* Guard against zero/negative dimensions and size_t multiplication
+     * overflow before we hand mag_size to malloc. */
+    if (max_blocks <= 0 || num_bins <= 0) {
+        LV_LOG_ERROR("FT8 worker: invalid dimensions (max_blocks=%d, num_bins=%d)", max_blocks, num_bins);
+        goto error_cleanup;
+    }
+
+    const size_t mag_stride = (size_t)TIME_OSR * (size_t)FREQ_OSR * (size_t)num_bins * sizeof(WF_ELEM_T);
+    if (mag_stride == 0 || (size_t)max_blocks > SIZE_MAX / mag_stride) {
+        LV_LOG_ERROR("FT8 worker: mag_size calculation overflow");
+        goto error_cleanup;
+    }
+
+    size_t mag_size = (size_t)max_blocks * mag_stride;
 
     wf.max_blocks = max_blocks;
     wf.num_bins = num_bins;
@@ -101,6 +163,10 @@ void ftx_worker_init(int sample_rate, ftx_protocol_t protocol) {
     wf.freq_osr = FREQ_OSR;
     wf.block_stride = TIME_OSR * FREQ_OSR * num_bins;
     wf.mag = (uint8_t *)malloc(mag_size);
+    if (!wf.mag) {
+        LV_LOG_ERROR("FT8 worker: wf.mag malloc failed");
+        goto error_cleanup;
+    }
     wf.protocol = protocol;
 
     find_candidates_at = n_tones - sync_num;
@@ -110,10 +176,18 @@ void ftx_worker_init(int sample_rate, ftx_protocol_t protocol) {
     float fft_norm = 2.0f / nfft;
     time_buf = (float complex *)malloc(nfft * sizeof(float complex));
     freq_buf = (float complex *)malloc(nfft * sizeof(float complex));
+    if (!time_buf || !freq_buf) {
+        LV_LOG_ERROR("FT8 worker: time_buf/freq_buf malloc failed");
+        goto error_cleanup;
+    }
     fft = fft_create_plan(nfft, time_buf, freq_buf, LIQUID_FFT_FORWARD, 0);
     frame_window = windowcf_create(nfft);
 
     rx_window = malloc(nfft * sizeof(complex float));
+    if (!rx_window) {
+        LV_LOG_ERROR("FT8 worker: rx_window malloc failed");
+        goto error_cleanup;
+    }
     float window_norm = 2.0f / nfft;
 
     for (uint16_t i = 0; i < nfft; i++) {
@@ -121,20 +195,41 @@ void ftx_worker_init(int sample_rate, ftx_protocol_t protocol) {
     }
 
     ftx_worker_reset();
+    return;
+
+error_cleanup:
+    ftx_worker_free();
 }
 
 /**
- * Cleanup worker
+ * Cleanup worker. Safe to call multiple times or on a half-initialised
+ * worker (partial allocations are skipped via NULL checks).
  */
 void ftx_worker_free() {
-    free(wf.mag);
-    windowcf_destroy(frame_window);
-
-    free(time_buf);
-    free(freq_buf);
-    fft_destroy_plan(fft);
-
-    free(rx_window);
+    if (wf.mag) {
+        free(wf.mag);
+        wf.mag = NULL;
+    }
+    if (frame_window) {
+        windowcf_destroy(frame_window);
+        frame_window = NULL;
+    }
+    if (fft) {
+        fft_destroy_plan(fft);
+        fft = NULL;
+    }
+    if (time_buf) {
+        free(time_buf);
+        time_buf = NULL;
+    }
+    if (freq_buf) {
+        free(freq_buf);
+        freq_buf = NULL;
+    }
+    if (rx_window) {
+        free(rx_window);
+        rx_window = NULL;
+    }
     hashtable_delete();
 }
 
@@ -153,7 +248,8 @@ void ftx_worker_reset() {
 
 bool ftx_worker_generate_tx_samples(const char *text, const uint16_t signal_freq, const uint32_t sample_rate,
                                     int16_t **samples, uint32_t *n_samples) {
-    ftx_message_t    msg;
+    ftx_message_t msg;
+    ftx_message_init(&msg);
     ftx_message_rc_t rc = ftx_message_encode(&msg, &hash_if, text);
 
     if (rc != FTX_MESSAGE_RC_OK) {
@@ -175,7 +271,12 @@ bool ftx_worker_generate_tx_samples(const char *text, const uint16_t signal_freq
         break;
     }
 
-    *samples = gfsk_synth(tones, n_tones, signal_freq, symbol_bt, symbol_period, sample_rate, n_samples);
+    int16_t *out = gfsk_synth(tones, n_tones, signal_freq, symbol_bt, symbol_period, sample_rate, n_samples);
+    if (!out) {
+        LV_LOG_ERROR("gfsk_synth allocation failed");
+        return false;
+    }
+    *samples = out;
     return true;
 }
 
@@ -228,7 +329,7 @@ void ftx_worker_put_rx_samples(float complex *samples, uint32_t n_samples) {
 void ftx_worker_decode(decoded_msg_cb msg_cb, bool last, void *user_data) {
     if (wf.num_blocks >= find_candidates_at) {
         if (num_candidates == 0) {
-            num_candidates = ftx_find_candidates(&wf, MAX_CANDIDATES, candidate_list, MIN_SCORE);
+            num_candidates = ftx_find_candidates(&wf, MAX_CANDIDATES, candidate_list, ft8lib_min_score);
         } else if (last) {
             // Last decoding
             decode_messages(&wf, &num_candidates, candidate_list, decoded, decoded_hashtable, LDPC_ITERATIONS, msg_cb,
@@ -254,7 +355,10 @@ static void decode_messages(const ftx_waterfall_t *wf, int *num_candidates, ftx_
                             decoded_msg_cb msg_cb, void *user_data) {
     // Go over candidates and attempt to decode messages
 
-    int to_delete_idx[*num_candidates];
+    /* Use fixed-size array sized to MAX_CANDIDATES instead of a VLA based
+     * on *num_candidates so a zero value cannot create a zero-length VLA
+     * (undefined behaviour). */
+    int to_delete_idx[MAX_CANDIDATES];
     int to_delete_size = 0;
 
     for (int idx = 0; idx < *num_candidates; ++idx) {
@@ -264,6 +368,13 @@ static void decode_messages(const ftx_waterfall_t *wf, int *num_candidates, ftx_
         if ((cand->time_offset + n_tones - sync_num) >= wf->num_blocks) {
             continue;
         }
+
+        /* Defensive: to_delete_idx is bounded by MAX_CANDIDATES. */
+        if (to_delete_size >= MAX_CANDIDATES) {
+            LV_LOG_WARN("Too many candidates to delete, truncating to %d", MAX_CANDIDATES);
+            break;
+        }
+
         to_delete_idx[to_delete_size++] = idx;
 
         ftx_message_t       message;
@@ -284,6 +395,7 @@ static void decode_messages(const ftx_waterfall_t *wf, int *num_candidates, ftx_
         int  idx_hash = message.hash % MAX_DECODED_MESSAGES;
         bool found_empty_slot = false;
         bool found_duplicate = false;
+        int  probes = 0;
         do {
             if (decoded_hashtable[idx_hash] == NULL) {
                 LV_LOG_INFO("Found an empty slot");
@@ -294,10 +406,10 @@ static void decode_messages(const ftx_waterfall_t *wf, int *num_candidates, ftx_
                 found_duplicate = true;
             } else {
                 LV_LOG_INFO("Hash table clash!");
-                // Move on to check the next entry in hash table
                 idx_hash = (idx_hash + 1) % MAX_DECODED_MESSAGES;
+                probes++;
             }
-        } while (!found_empty_slot && !found_duplicate);
+        } while (!found_empty_slot && !found_duplicate && probes < MAX_DECODED_MESSAGES);
 
         if (found_empty_slot) {
             // Fill the empty hashtable slot

--- a/src/ft8/worker.c
+++ b/src/ft8/worker.c
@@ -71,25 +71,13 @@ static void ftx_min_score_load_or_create(void) {
         ft8lib_min_score = FTXLIB_MIN_SCORE_DEFAULT;
         return;
     }
-    char buf[64] = {0};
-    bool ok = false;
-    if (fgets(buf, sizeof(buf), f)) {
-        char *end = NULL;
-        errno = 0;
-        long v = strtol(buf, &end, 10);
-        if ((errno == 0) && (end != buf) && (v >= 0) && (v <= 32767)) {
-            while (end && *end && isspace((unsigned char)*end)) end++;
-            if ((end != NULL) && (*end == '\0')) {
-                ft8lib_min_score = (int)v;
-                ok = true;
-            }
-        }
-    }
+    int val = FTXLIB_MIN_SCORE_DEFAULT;
+    if (fscanf(f, "%d", &val) != 1)
+        val = FTXLIB_MIN_SCORE_DEFAULT;
     fclose(f);
-    if (!ok) {
-        ft8lib_min_score = FTXLIB_MIN_SCORE_DEFAULT;
+    ft8lib_min_score = val;
+    if (val == FTXLIB_MIN_SCORE_DEFAULT)
         ftx_min_score_write_default();
-    }
 }
 
 static int             num_candidates;
@@ -141,13 +129,6 @@ void ftx_worker_init(int sample_rate, ftx_protocol_t protocol) {
     const int max_blocks = (int)(slot_period / symbol_period);
     // TODO: skip bins outside filter
     const int num_bins = sample_rate * symbol_period / 2;
-
-    /* Guard against zero/negative dimensions and size_t multiplication
-     * overflow before we hand mag_size to malloc. */
-    if (max_blocks <= 0 || num_bins <= 0) {
-        LV_LOG_ERROR("FT8 worker: invalid dimensions (max_blocks=%d, num_bins=%d)", max_blocks, num_bins);
-        goto error_cleanup;
-    }
 
     const size_t mag_stride = (size_t)TIME_OSR * (size_t)FREQ_OSR * (size_t)num_bins * sizeof(WF_ELEM_T);
     if (mag_stride == 0 || (size_t)max_blocks > SIZE_MAX / mag_stride) {
@@ -355,9 +336,11 @@ static void decode_messages(const ftx_waterfall_t *wf, int *num_candidates, ftx_
                             decoded_msg_cb msg_cb, void *user_data) {
     // Go over candidates and attempt to decode messages
 
+    if (!num_candidates || *num_candidates <= 0) return;
+
     /* Use fixed-size array sized to MAX_CANDIDATES instead of a VLA based
      * on *num_candidates so a zero value cannot create a zero-length VLA
-     * (undefined behaviour). */
+     * (undefined behaviour). The early-return guard above makes this safe. */
     int to_delete_idx[MAX_CANDIDATES];
     int to_delete_size = 0;
 
@@ -367,12 +350,6 @@ static void decode_messages(const ftx_waterfall_t *wf, int *num_candidates, ftx_
         // Skip candidates, that are not fully received
         if ((cand->time_offset + n_tones - sync_num) >= wf->num_blocks) {
             continue;
-        }
-
-        /* Defensive: to_delete_idx is bounded by MAX_CANDIDATES. */
-        if (to_delete_size >= MAX_CANDIDATES) {
-            LV_LOG_WARN("Too many candidates to delete, truncating to %d", MAX_CANDIDATES);
-            break;
         }
 
         to_delete_idx[to_delete_size++] = idx;

--- a/src/tx_info.c
+++ b/src/tx_info.c
@@ -211,6 +211,14 @@ static void update_tx_info(void *arg) {
     lv_label_set_text_fmt(alc_label, "ALC: %1.1f", alc);
     lv_label_set_text_fmt(vswr_label, "%.2f", vswr);
     lv_label_set_text_fmt(pwr_label, "%.2f", pwr);
+    /* PWR / SWR bars are drawn in obj's DRAW_MAIN_END handler. The labels
+     * only invalidate their own (small) bounding boxes, which does not cover
+     * the bar area. Explicitly invalidate the container so the bars repaint
+     * on every update -- previously we relied on the main_screen spectrum
+     * widget (which fully overlaps tx_info) being invalidated periodically
+     * by spectrum_data(), but FT8 dialog turns the spectrum/waterfall DSP
+     * off, removing that side effect. */
+    lv_obj_invalidate(obj);
     if (params.mag_alc.x) {
         lv_obj_add_flag(alc_label, LV_OBJ_FLAG_HIDDEN);
         msg_tiny_set_text_fmt("ALC: %.1f", alc);

--- a/src/widgets/lv_waterfall.c
+++ b/src/widgets/lv_waterfall.c
@@ -85,13 +85,22 @@ void lv_waterfall_clear_data(lv_obj_t * obj) {
 
     memset(waterfall->dsc->data, 0, waterfall->dsc->data_size);
     lv_img_cache_invalidate_src(waterfall->dsc);
+    lv_obj_invalidate(obj);
 }
 
 void lv_waterfall_add_data(lv_obj_t * obj, float * data, uint16_t cnt) {
+    struct timespec ts = {0, 0};
+    lv_waterfall_add_data_with_ts(obj, data, cnt, ts);
+}
+
+void lv_waterfall_add_data_with_ts(lv_obj_t * obj, float * data, uint16_t cnt, struct timespec ts) {
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
     lv_waterfall_t  *waterfall = (lv_waterfall_t *)obj;
     lv_img_dsc_t    *dsc = waterfall->dsc;
+
+    /* Store timestamp for time-aligned processing (e.g. DNF). */
+    waterfall->frame_ts = ts;
 
     if (!dsc || !waterfall->palette) {
         return;
@@ -120,6 +129,15 @@ void lv_waterfall_add_data(lv_obj_t * obj, float * data, uint16_t cnt) {
 
         lv_img_buf_set_px_color(dsc, x, 0, waterfall->palette[id]);
     }
+
+    lv_img_cache_invalidate_src(dsc);
+    lv_obj_invalidate(obj);
+}
+
+struct timespec lv_waterfall_get_frame_ts(lv_obj_t * obj) {
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_waterfall_t *waterfall = (lv_waterfall_t *)obj;
+    return waterfall->frame_ts;
 }
 
 void lv_waterfall_set_min(lv_obj_t * obj, int16_t val) {

--- a/src/widgets/lv_waterfall.h
+++ b/src/widgets/lv_waterfall.h
@@ -17,6 +17,8 @@ extern "C" {
 
 #include "lvgl/lvgl.h"
 
+#include <time.h>
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -33,6 +35,8 @@ typedef struct {
 
     int16_t         min;
     int16_t         max;
+
+    struct timespec frame_ts;   /* wall-clock timestamp of most recent PSD frame */
 } lv_waterfall_t;
 
 extern const lv_obj_class_t lv_waterfall_class;
@@ -52,6 +56,12 @@ void lv_waterfall_set_size(lv_obj_t * obj, lv_coord_t w, lv_coord_t h);
 
 void lv_waterfall_clear_data(lv_obj_t * obj);
 void lv_waterfall_add_data(lv_obj_t * obj, float * data, uint16_t cnt);
+
+/* Add data with wall-clock timestamp for time-aligned processing (e.g. DNF). */
+void lv_waterfall_add_data_with_ts(lv_obj_t * obj, float * data, uint16_t cnt, struct timespec ts);
+
+/* Return the timestamp of the most recent PSD frame, or {0,0} if none yet. */
+struct timespec lv_waterfall_get_frame_ts(lv_obj_t * obj);
 
 void lv_waterfall_set_min(lv_obj_t *obj, int16_t val);
 void lv_waterfall_set_max(lv_obj_t *obj, int16_t val);


### PR DESCRIPTION
# refactor(ft8): split dialog_ft8.c into modules

Split the 1353-line monolithic `dialog_ft8.c` into four modules plus infrastructure fixes. Net diff: **19 files, +1534/−568**, with `dialog_ft8.c` reduced to **987 lines (−27%)**. Each of the 4 commits is self-contained and buildable.

No new FT8 features — pure structural refactor plus defensive hardening and CPU optimization.

---

## Commit 1 — fix(ft8): defensive hardening in worker, gfsk, qso

**`src/ft8/worker.c`** (+146/−16)

| Change | What / Why |
|--------|-------------|
| Add `#include <stdint.h>`, `<errno.h>`, `<ctype.h>` | Missing standard headers |
| Dynamic `ftx_min_score` from `/mnt/ft8lib_min_score.txt` | Reads int value; creates default if file missing or unparseable. Lets power users tune sensitivity without recompiling |
| `mag_size` overflow check | Guard `max_blocks * TIME_OSR * FREQ_OSR * num_bins * sizeof(WF_ELEM_T)` before `malloc` |
| `wf.mag`, `time_buf`, `freq_buf`, `rx_window` malloc NULL checks | Safe OOM failure with `goto error_cleanup` |
| `ftx_worker_free` NULL guards | Every pointer checked before free/destroy; safe to call on half-init worker |
| `ftx_message_init(&msg)` before encode | Explicit init, previously relied on implicit zero |
| `gfsk_synth` return NULL check | OOM guard in `ftx_worker_generate_tx_samples` |
| VLA → fixed `int[MAX_CANDIDATES]` | Replace `int to_delete_idx[*num_candidates]` (UB on zero-length VLA) with fixed array + bounds check |
| Hash collision `probes` counter | `while (!empty && !duplicate && probes < MAX_DECODED_MESSAGES)` — prevents infinite loop on pathological input |

**`src/ft8/gfsk.c`** (+3)

```c
int16_t *samples = malloc(sizeof(int16_t) * n_wave);
if (!samples) return NULL;  // NEW
```

**`src/ft8/qso.cpp`** (+20/−7)

| Change | Bug / Fix |
|--------|-----------|
| `save_qso_cb` NULL check | Guard before calling through callback pointer |
| `_saved = true` inside `if` block | **Bug fix**: original `if (can_be_saved()) save_qso_cb(...); _saved = true;` had missing braces — `_saved=true` ran unconditionally. Now only when `can_be_saved()` |
| `tokens.empty()` early return (×2) | Prevents OOB on empty input |
| `!token.empty()` before `token[0] == '<'` | OOB guard on empty token in angled-bracket strip loop |
| `has_current()` + C wrapper | New: `ftx_qso_processor_has_current(p)` |

**`src/ft8/qso.h`** — declares `has_current()` and C extern.

---

## Commit 2 — feat(dsp): waterfall/spectrum gating API + tx_info repaint fix

**`src/dsp.cpp`** (+51/−1)

Two `std::atomic<bool>` flags:

```cpp
static std::atomic<bool> waterfall_enabled{true};
static std::atomic<bool> spectrum_enabled{true};
```

`dsp_process` internals wrapped in atomic guards:

```cpp
// was:
sp_sg->execute_block(buf_filtered, sp_n_samples);
wf_sg->execute_block(samples_for_wf, wf_n_samples);
update_spectrum(sp_sg, now, tx, base_freq);

// now:
if (spectrum_enabled.load(std::memory_order_relaxed)) {
    sp_sg->execute_block(buf_filtered, sp_n_samples);
    update_spectrum(sp_sg, now, tx, base_freq);
}
if (wf_sg && waterfall_enabled.load(std::memory_order_relaxed)) {
    wf_sg->execute_block(samples_for_wf, wf_n_samples);
    update_waterfall(wf_sg, now, tx, base_freq);
}
```

Public C API (in `extern "C"` block):

```c
void dsp_set_waterfall_enabled(bool enabled);  // resets psd_delay + waterfall_time on re-enable
void dsp_set_spectrum_enabled(bool enabled);   // resets psd_delay + spectrum_time on re-enable
```

**`src/dsp.h`** — declares both.

**`src/tx_info.c`** (+8)

```c
lv_obj_invalidate(obj);  // NEW, at end of update_tx_info()
```

The PWR/SWR bars are drawn in the container's `DRAW_MAIN_END` handler. Label invalidation only covers the text bbox — not the bar area. When a later commit gates main-screen DSP (stopping spectrum redraw which normally triggers container paint), the bars freeze. Forced `lv_obj_invalidate` ensures bars repaint on every `update_tx_info` tick.

---

## Commit 3 — feat(widgets): lv_waterfall frame_ts hook + invalidate after add/clear

**`src/widgets/lv_waterfall.h`** (+10)

```c
#include <time.h>                           // NEW

typedef struct {
    // ... existing fields ...
    struct timespec frame_ts;               // NEW: wall-clock ts of most recent PSD frame
} lv_waterfall_t;

void lv_waterfall_add_data_with_ts(lv_obj_t *obj, float *data, uint16_t cnt, struct timespec ts);  // NEW
struct timespec lv_waterfall_get_frame_ts(lv_obj_t *obj);                                            // NEW
```

**`src/widgets/lv_waterfall.c`** (+18)

```c
// add_data now delegates:
void lv_waterfall_add_data(lv_obj_t *obj, float *data, uint16_t cnt) {
    struct timespec ts = {0, 0};
    lv_waterfall_add_data_with_ts(obj, data, cnt, ts);  // existing callers unchanged
}

void lv_waterfall_add_data_with_timestamp(...) {
    waterfall->frame_ts = ts;              // store timestamp
    // ... palette rendering ...
    lv_img_cache_invalidate_src(dsc);      // NEW
    lv_obj_invalidate(obj);                // NEW — needed when main DSP clock is gated
}

void lv_waterfall_clear_data(lv_obj_t *obj) {
    // ... existing memset ...
    lv_obj_invalidate(obj);                // NEW
}
```

`frame_ts` is infrastructure for future time-aligned processing (DNF). The `lv_obj_invalidate` additions are needed now because the FT8 dialog will gate main-screen DSP (commit 4), and the waterfall widget must self-invalidate to keep refreshing.

---

## Commit 4 — refactor(ft8): split dialog_ft8.c into table_view/cq_scheduler/tx_worker/audio_worker

This is the main refactor. `dialog_ft8.c` drops from 1353 to 987 lines. The file becomes a thin coordinator: LVGL event binding, button handlers, and module lifecycle management.

### New module: `src/ft8/table_view.{c,h}` (+446 lines)

**Public API:**

```c
void      table_view_build(lv_obj_t *parent, lv_coord_t x, lv_coord_t y, lv_coord_t w, lv_coord_t h);
void      table_view_destroy(void);
lv_obj_t *table_view_obj(void);
void      table_view_set_press_cb(table_view_press_cb_t cb);
void      table_view_set_actions(const table_view_actions_t *actions);
void      table_view_reset(void);
void      table_view_push_ui(const cell_data_t *src);
void      table_view_add_msg_cb(void *data);  // scheduler_fn_t trampoline
```

**Types exported:**

```c
typedef enum {
    CELL_RX_INFO = 0, CELL_RX_MSG, CELL_RX_CQ, CELL_RX_TO_ME, CELL_TX_MSG,
} ft8_cell_type_t;

typedef struct {
    ft8_cell_type_t  cell_type;
    int16_t          dist;
    bool             odd;
    ftx_msg_meta_t   meta;
    char             text[64];
    qso_log_search_worked_t worked_type;
} cell_data_t;

typedef struct {
    void (*on_close)(void);
    void (*on_vol_change)(int32_t d);
} table_view_actions_t;

typedef void (*table_view_press_cb_t)(const cell_data_t *cell);
```

**Key fix: parallel array replaces `user_data`**

Original `lv_table` stored `cell_data_t *` via `lv_table_set_cell_user_data` and freed with `lv_mem_free` — use-after-free and double-free when cells were reused or rows truncated. Replaced with:

```c
static cell_data_t s_row_cell[MAX_TABLE_MSG];
```

Each row index maps to a fixed cell slot. Lifecycle is decoupled from table row — no malloc/free inside the table rendering path.

### New module: `src/ft8/cq_scheduler.{c,h}` (+76 lines)

**Single API:**

```c
void cq_make_message(const char *callsign, const char *qth,
                     const char *cq_mod, char *out);
```

Uses `snprintf` to compose CQ text, then `ftx_message_encode` → `ftx_message_decode` for validation. Any codec error logs via `LV_LOG_USER` but does not clear `out` — matches the historical `make_cq_msg()` behavior exactly.

### New module: `src/ft8/tx_worker.{c,h}` (+165 lines)

```c
typedef bool (*tx_abort_fn_t)(void *ctx);

bool tx_worker_run(const char    *tx_text,
                   int32_t        audio_sample_rate,
                   float          base_gain_offset,
                   tx_abort_fn_t  abort_check,
                   void          *abort_check_ctx);
```

Encapsulates: `gfsk_synth` → per-block ALC gain correction (`base_gain_offset`) → radio TX frequency tune → audio playback loop. The `abort_check` callback is polled each block so the dialog can preempt TX (e.g., user closes dialog mid-transmit).

### New module: `src/ft8/audio_worker.{c,h}` (+437 lines)

**Full encapsulation of the decode pipeline:**

- Decode thread lifecycle (start / cooperative stop / destroy)
- Audio ring buffer (`cbuffercf`) fed from radio callback
- DSP: `firdecim_crcf` decimation + spectrogram (`spgramcf`)
- `ftx_worker` integration (feed samples, decode, receive callbacks)

**Cooperative stop replaces `pthread_cancel`:**

```c
struct audio_worker_s {
    atomic_bool      stop_requested;
    pthread_mutex_t  cond_mutex;
    pthread_cond_t   wakeup_cond;
    pthread_t        thread;
    // ... DSP state ...
};
```

- `audio_worker_stop()`: set atomic flag → `pthread_cond_signal` → `pthread_join`
- Thread checks `stop_requested` each iteration, exits cleanly with all resources released
- Avoids `pthread_cancel` UB (locks held mid-section, malloc interrupted)

**Callback API:**

```c
typedef struct {
    void (*on_message)(const char *text, int snr, float freq_hz,
                       float time_sec, const slot_info_t *info, void *ctx);
    void (*on_psd)(const float *psd, uint16_t nfft,
                   float sec_since_slot_start, const slot_info_t *info, void *ctx);
    void (*on_slot_end)(const slot_info_t *info, void *ctx);
    void (*on_tick)(const slot_info_t *info, bool new_slot,
                    float sec_since_slot_start, void *ctx);
    void *ctx;
} audio_worker_cb_t;
```

All callbacks run on the worker thread. Handlers touching LVGL must `scheduler_put()`.

**Simplified `slot_info_t`:**

```c
typedef struct {
    bool odd;
    bool answer_generated;
} slot_info_t;
```

`slot_start` field intentionally excluded (needed for FT8 log feature, not here).

### dialog_ft8.c changes (coordinator role)

**Removed** (moved into modules):

- 3 macros: `MAX_TABLE_MSG`, `CLEAN_N_ROWS`, `WAIT_SYNC_TEXT`
- 3 typedefs: `ft8_cell_type_t`, `cell_data_t`, `slot_info_t`
- Static variables: `lv_obj_t *table`, `pthread_mutex_t audio_mutex`, `cbuffercf audio_buf`, `pthread_t thread`, `firdecim_crcf decim`, `float complex *decim_buf`, `waterfall_nfft`, `waterfall_sg`, `waterfall_psd`, `waterfall_fps_ms`, `waterfall_time`
- Functions: `scroll_table_down_cb`, `truncate_table`, `add_msg_cb`, `table_draw_part_begin_cb`, `table_draw_part_end_cb`, `cell_press_cb`, `make_cq_msg`, `get_correction`, `tx_worker()`, `waterfall_process`, `rx_worker`, `decode_thread`, `received_message_cb`

**Added:**

- `#include "ft8/table_view.h"`, `"ft8/cq_scheduler.h"`, `"ft8/tx_worker.h"`, `"ft8/audio_worker.h"`
- `#include "dsp.h"` (for `dsp_set_waterfall_enabled` from commit 2)
- `#define table (table_view_obj())` — compatibility alias for existing fade/group/anim call sites
- `static audio_worker_t *audio_worker = NULL;`
- Callbacks: `on_table_press`, `on_table_close`, `on_table_vol_change`, `on_message_cb`, `on_psd_cb`, `on_slot_end_cb`, `on_tick_cb`, `tx_should_abort_cb`
- `construct_cb`: `dsp_set_waterfall_enabled(false)` + `dsp_set_spectrum_enabled(false)` → `table_view_build/set_press_cb/set_actions` → `audio_worker_create/start`
- `destruct_cb`: `audio_worker_stop/destroy` → `table_view_destroy` → `dsp_set_waterfall/spectrum_enabled(true)`
- `audio_cb`: 1-liner delegation to `audio_worker_feed()`

### CMakeLists.txt

Added `audio_worker.c`, `cq_scheduler.c`, `table_view.c`, `tx_worker.c` to `ft8` static library.

---

## What is intentionally NOT included

These exist in `feature/ft8-enhance` but are excluded from this refactor. Each will be a separate follow-up PR:

| Module / Feature | Lines | Reason |
|-----------------|-------|--------|
| `ft8/qso_state.{c,h}` | 377 | Dead code — no callers in source branch |
| `ft8/auto_sel.{cpp,h}` | ~200 | AutoSel feature |
| `ft8/auto_dnf.{c,h}` | ~350 | Auto DNF feature |
| `ft8/ft8_log.{c,h}` | ~280 | FT8 logging feature |
| `ft8/params.{c,h}` | ~200 | Config subsystem |
| `force_free_text` param | scattered | Free MSG feature |
| `slot_info_t.slot_start`, RX header `llround` | ~30 | FT8 log feature |
| `qso_log_search_worked_grid` + `db_mutex` | ~40 | Auto DNF feature |
| `lv_waterfall_add_marker_line` | ~30 | Auto DNF feature |
| XIT switching, tail-align in tx_worker | ~100 | Separate optimizations |
| LEFT/RIGHT key swap in table_view | ~10 | UX change, not a refactor |

---

## Behavioral differences from `main`

| Item | `main` | This PR | Classification |
|------|--------|---------|---------------|
| Main-screen waterfall/spectrum during FT8 | Always computed | Paused while FT8 dialog open | CPU optimization; auto-restores on exit |
| PWR/SWR bar refresh during TX | Driven by main clock tick | Forced `lv_obj_invalidate` | Side-effect fix of DSP gating |
| Decode thread shutdown | `pthread_cancel` | Cooperative stop via atomic flag + cond + join | Stability fix |
| `cell_data_t` lifecycle | `lv_table` `user_data` + `lv_mem_free` | Parallel array `s_row_cell[]` | Fixes use-after-free / double-free |
| `Candidate::save_qso` `_saved=true` | Unconditionally executed (bug) | Only when `can_be_saved()` | Bug fix |
| Table LEFT/RIGHT arrow keys | Original behavior | **Unchanged** (original) | UX change excluded |

---

## Verification

- **Build**: Docker `ubuntu:24.04` + buildroot, `make -j4 FT8 x6100_gui` — **0 errors**
- **UI parity**: 3 pages × 5 buttons, all labels and press callbacks **100% identical** to `main`
- **Warnings**: Only pre-existing `-Wdiscarded-qualifiers` in `lv_waterfall.c` (unrelated to this PR)
